### PR TITLE
Parse funccalls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,8 @@ set(LIBDS_SOURCE_FILES deps/libds/array.c
 set(STREAM_SOURCE_FILES lib/stream/streamreader.c)
 
 # mscript source files
-set(MSCRIPT_SOURCE_FILES src/lang.c
+set(MSCRIPT_SOURCE_FILES src/bytecode.c
+                         src/lang.c
                          src/lexer.c
                          src/obj.c
                          src/parser.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # PROJECT METADATA
 #######################################################################
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.2)
 project(mscript)
 
 enable_testing()
@@ -32,7 +32,6 @@ include_directories(${PROJECT_SOURCE_DIR}/lib)
 # Compiler and Linker flags
 set(C_WARNING_FLAGS "-Wall -Wextra -pedantic")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -g ${C_WARNING_FLAGS}")
-set(C_LINKER_FLAGS  "-lreadline")
 
 #######################################################################
 # MAIN EXECUTABLE
@@ -61,8 +60,10 @@ add_executable(mscript ${MSCRIPT_SOURCE_FILES}
                        ${STREAM_SOURCE_FILES}
                        ${LIBDS_SOURCE_FILES}
                        src/main.c)
-set_target_properties(mscript PROPERTIES
-                              LINK_FLAGS ${C_LINKER_FLAGS})
+if(UNIX)
+    target_link_libraries(mscript m)
+endif(UNIX)
+target_link_libraries(mscript readline)
 
 #######################################################################
 # TEST EXECUTABLE
@@ -84,3 +85,7 @@ add_executable(mscript_test ${MSCRIPT_SOURCE_FILES}
                             ${LIBDS_SOURCE_FILES})
 set_target_properties(mscript_test PROPERTIES
                                    COMPILE_FLAGS ${C_TEST_WARNING_FLAGS})
+if(UNIX)
+    target_link_libraries(mscript_test m)
+endif(UNIX)
+target_link_libraries(mscript_test readline)

--- a/deps/libds/array.c
+++ b/deps/libds/array.c
@@ -53,6 +53,22 @@ DSArray* dsarray_new_cap(size_t cap, dsarray_compare_fn cmpfn, dsarray_free_fn f
     return array;
 }
 
+DSArray *dsarray_new_lit(void **list, size_t len, size_t cap, dsarray_compare_fn cmpfn, dsarray_free_fn freefn) {
+    if ((!list) || (cap < len)) { return NULL; }
+
+    DSArray *array = dsarray_new_cap(cap, cmpfn, freefn);
+    if (!array) {
+        return NULL;
+    }
+
+    for (size_t i = 0; i < cap; i++) {
+        array->data[i] = list[i];
+        array->len++;
+    }
+
+    return array;
+}
+
 void dsarray_destroy(DSArray *array) {
     if (!array) { return; }
     dsarray_free(array);

--- a/deps/libds/array.c
+++ b/deps/libds/array.c
@@ -40,7 +40,7 @@ DSArray* dsarray_new_cap(size_t cap, dsarray_compare_fn cmpfn, dsarray_free_fn f
         return NULL;
     }
 
-    array->data = calloc(cap, sizeof(void*) * cap);
+    array->data = calloc(cap, sizeof(void *));
     if (!array->data) {
         free(array);
         return NULL;
@@ -60,23 +60,23 @@ void dsarray_destroy(DSArray *array) {
     free(array);
 }
 
-size_t dsarray_len(DSArray *array) {
+size_t dsarray_len(const DSArray *array) {
     assert(array);
     return array->len;
 }
 
-size_t dsarray_cap(DSArray *array) {
+size_t dsarray_cap(const DSArray *array) {
     assert(array);
     return array->cap;
 }
 
-void* dsarray_get(DSArray *array, size_t index) {
+void* dsarray_get(const DSArray *array, size_t index) {
     if (!array) { return NULL; }
     if (index > array->len) { return NULL; }
     return array->data[index];
 }
 
-void* dsarray_top(DSArray *array) {
+void* dsarray_top(const DSArray *array) {
     if (!array) { return NULL; }
     if (array->len == 0) { return NULL; }
     return array->data[array->len-1];
@@ -171,7 +171,7 @@ void dsarray_clear(DSArray *array) {
     array->len = 0;
 }
 
-int dsarray_index(DSArray *array, void *elem) {
+int dsarray_index(const DSArray *array, void *elem) {
     if ((!array) || (!elem)) {
         return DSARRAY_NULL_POINTER;
     }
@@ -237,7 +237,7 @@ static bool dsarray_resize(DSArray *array, size_t cap) {
     }
 
     void **cache = array->data;
-    array->data = malloc(sizeof(void*) * cap);
+    array->data = calloc(cap, sizeof(void *));
     if (!array->data) {
         array->data = cache;
         return false;

--- a/deps/libds/array.h
+++ b/deps/libds/array.h
@@ -65,7 +65,7 @@ static const int DSARRAY_NO_CMP_FUNC = -3;
 * @returns a new @c DSArray object or @c NULL if memory could not be
 *          allocated
 */
-DSArray* dsarray_new(dsarray_compare_fn cmpfn, dsarray_free_fn freefn);
+DSArray *dsarray_new(dsarray_compare_fn cmpfn, dsarray_free_fn freefn);
 
 /**
 * @brief Create a new @c DSArray object with @c cap slots and the given
@@ -82,7 +82,7 @@ DSArray* dsarray_new(dsarray_compare_fn cmpfn, dsarray_free_fn freefn);
 * @returns a new @c DSArray object or @c NULL if memory could not be
 *          allocated
 */
-DSArray* dsarray_new_cap(size_t cap, dsarray_compare_fn cmpfn, dsarray_free_fn freefn);
+DSArray *dsarray_new_cap(size_t cap, dsarray_compare_fn cmpfn, dsarray_free_fn freefn);
 
 /**
 * @brief Destroy a @c DSArray object.
@@ -99,7 +99,7 @@ void dsarray_destroy(DSArray *array);
 * @param array a @c DSArray object
 * @returns the number of elements in @c array
 */
-size_t dsarray_len(DSArray *array);
+size_t dsarray_len(const DSArray *array);
 
 /**
 * @brief Return the capacity of a @c DSArray .
@@ -107,7 +107,7 @@ size_t dsarray_len(DSArray *array);
 * @param array a @c DSArray object
 * @returns the number of elements that @c array can hold
 */
-size_t dsarray_cap(DSArray *array);
+size_t dsarray_cap(const DSArray *array);
 
 /**
 * @brief Return the object stored at the given index.
@@ -117,7 +117,7 @@ size_t dsarray_cap(DSArray *array);
 * @returns @c NULL if the index has no element or is invalid; the
 *          object otherwise
 */
-void* dsarray_get(DSArray *array, size_t index);
+void *dsarray_get(const DSArray *array, size_t index);
 
 /**
 * @brief Return the top element in the array without popping it.
@@ -126,7 +126,7 @@ void* dsarray_get(DSArray *array, size_t index);
 * @returns @c NULL if there are no elements in the array; the top of
 *          the stack (array) otherwise
 */
-void* dsarray_top(DSArray *array);
+void *dsarray_top(const DSArray *array);
 
 /**
 * @brief Perform the given function on each object in the array.
@@ -193,7 +193,7 @@ bool dsarray_insert(DSArray *array, void *elem, size_t index);
 * @returns a pointer to the element or @c NULL if the element cannot be
 *          found or no comparator function was specified
 */
-void* dsarray_remove(DSArray *array, void *elem);
+void *dsarray_remove(DSArray *array, void *elem);
 
 /**
 * @brief Remove the element at the given index and return it.
@@ -206,7 +206,7 @@ void* dsarray_remove(DSArray *array, void *elem);
 *          found or no comparator function was specified or the index was
 *          invalid
 */
-void* dsarray_remove_index(DSArray *array, size_t index);
+void *dsarray_remove_index(DSArray *array, size_t index);
 
 /**
 * @brief Pop the top element from the array.
@@ -216,7 +216,7 @@ void* dsarray_remove_index(DSArray *array, size_t index);
 * @param array a @c DSArray object
 * @returns a pointer to the top element or @c NULL if the array is empty
 */
-void* dsarray_pop(DSArray *array);
+void *dsarray_pop(DSArray *array);
 
 /**
 * @brief Clear the entire array, freeing elements as they are removed.
@@ -239,7 +239,7 @@ void dsarray_clear(DSArray *array);
 * @returns the index of the element or @c DSARRAY_NOT_FOUND if the element
 *          is not found in the array
 */
-int dsarray_index(DSArray *array, void *elem);
+int dsarray_index(const DSArray *array, void *elem);
 
 /**
 * @brief Sort the array in ascending order using the given comparator function.

--- a/deps/libds/array.h
+++ b/deps/libds/array.h
@@ -85,6 +85,31 @@ DSArray *dsarray_new(dsarray_compare_fn cmpfn, dsarray_free_fn freefn);
 DSArray *dsarray_new_cap(size_t cap, dsarray_compare_fn cmpfn, dsarray_free_fn freefn);
 
 /**
+* @brief Create a new @c DSArray object with the given literal array items and
+* the given comparator and free function.
+*
+* This function will make a copy of the input list literal pointers, but it
+* will not make copies of the pointed-to objects (just as in every other
+* case with @c DSArray objects). Thus it is incumbent on callers to free the
+* input elements if they were previously responsible for that.
+*
+* Neither function pointer is required to create a new array. If the caller
+* does not specify a @c dsarray_compare_fn, then @c dsarray_sort will become
+* a no-op. Likewise, if no @c dsarray_free_fn is specified, then the array
+* will not free array elements when it is destroyed.
+*
+* @param list an array of elements to initialize in the array
+* @param len the starting capacity of the @c DSArray
+* @param cap the capacity of the @c DSArray ; must be greater than or equal to
+*            the specified length of the array literal
+* @param cmpfn a function which can compare two array elements
+* @param freefn a function which can free a array element
+* @returns a new @c DSArray object with the given elements or @c NULL if
+*          memory could not be allocated
+*/
+DSArray *dsarray_new_lit(void **list, size_t len, size_t cap, dsarray_compare_fn cmpfn, dsarray_free_fn freefn);
+
+/**
 * @brief Destroy a @c DSArray object.
 *
 * If a @c dsarray_free_fn was specified when the array was created, it will

--- a/deps/libds/buffer.c
+++ b/deps/libds/buffer.c
@@ -71,7 +71,7 @@ DSBuffer *dsbuf_new_buffer(size_t cap) {
 
     s->len = 0;
     s->cap = cap;
-    s->str = malloc(s->cap);
+    s->str = calloc(s->cap, 1);
     if (!s->str) {
         goto cleanup_dsbuf_buffer;
     }

--- a/deps/libds/buffer.c
+++ b/deps/libds/buffer.c
@@ -42,23 +42,21 @@ DSBuffer * dsbuf_new_l(const char *value, size_t len) {
 
     DSBuffer *s = malloc(sizeof(DSBuffer));
     if (!s) {
-        goto cleanup_gbuf;
+        return NULL;
     }
 
     s->len = len;
     s->cap = len * DSBUFFER_CAPACITY_FACTOR;
     s->str = malloc(s->cap);
     if (!s->str) {
-        goto cleanup_dsbuf_str;
+        goto cleanup_dsbuf;
     }
 
     memcpy(s->str, value, len);
     memset(&s->str[len], '\0', (s->cap - len));
     return s;
 
-cleanup_dsbuf_str:
-    free(s->str);
-cleanup_gbuf:
+cleanup_dsbuf:
     free(s);
     return NULL;
 }
@@ -68,19 +66,17 @@ DSBuffer * dsbuf_new_buffer(size_t cap) {
 
     DSBuffer *s = malloc(sizeof(DSBuffer));
     if (!s) {
-        goto cleanup_dsbuf_buffer;
+        return NULL;
     }
 
     s->len = 0;
     s->cap = cap;
     s->str = calloc(s->cap, sizeof(char*));
     if (!s->str) {
-        goto cleanup_dsbuf_buffer_str;
+        goto cleanup_dsbuf_buffer;
     }
     return s;
 
-cleanup_dsbuf_buffer_str:
-    free(s->str);
 cleanup_dsbuf_buffer:
     free(s);
     return NULL;
@@ -91,6 +87,29 @@ void dsbuf_destroy(DSBuffer *str) {
     free(str->str);
     str->str = NULL;
     free(str);
+}
+
+DSBuffer *dsbuf_dup(const DSBuffer *str) {
+    if (!str) { return NULL; }
+
+    DSBuffer *s = malloc(sizeof(DSBuffer));
+    if (!s) {
+        return NULL;
+    }
+
+    s->len = str->len;
+    s->cap = str->cap;
+    s->str = malloc(s->cap);
+    if (!s->str) {
+        goto cleanup_dsbuf_dup;
+    }
+
+    memcpy(s->str, &str->str[0], s->len);
+    return s;
+
+cleanup_dsbuf_dup:
+    free(s);
+    return NULL;
 }
 
 size_t dsbuf_len(DSBuffer *str) {

--- a/deps/libds/buffer.c
+++ b/deps/libds/buffer.c
@@ -30,12 +30,12 @@ static int utf8_validate_char(const char *s, const char *e);
  * BUFFER PUBLIC FUNCTIONS
  */
 
-DSBuffer * dsbuf_new(const char *value) {
+DSBuffer *dsbuf_new(const char *value) {
     size_t len = strlen(value);
     return dsbuf_new_l(value, len);
 }
 
-DSBuffer * dsbuf_new_l(const char *value, size_t len) {
+DSBuffer *dsbuf_new_l(const char *value, size_t len) {
     if (len < 1) {
         return NULL;
     }
@@ -61,7 +61,7 @@ cleanup_dsbuf:
     return NULL;
 }
 
-DSBuffer * dsbuf_new_buffer(size_t cap) {
+DSBuffer *dsbuf_new_buffer(size_t cap) {
     cap = (cap < DSBUFFER_MINIMUM_CAPACITY) ? DSBUFFER_MINIMUM_CAPACITY : cap;
 
     DSBuffer *s = malloc(sizeof(DSBuffer));
@@ -71,7 +71,7 @@ DSBuffer * dsbuf_new_buffer(size_t cap) {
 
     s->len = 0;
     s->cap = cap;
-    s->str = calloc(s->cap, sizeof(char*));
+    s->str = malloc(s->cap);
     if (!s->str) {
         goto cleanup_dsbuf_buffer;
     }
@@ -112,12 +112,12 @@ cleanup_dsbuf_dup:
     return NULL;
 }
 
-size_t dsbuf_len(DSBuffer *str) {
+size_t dsbuf_len(const DSBuffer *str) {
     assert(str);
     return str->len;
 }
 
-size_t dsbuf_cap(DSBuffer *str) {
+size_t dsbuf_cap(const DSBuffer *str) {
     assert(str);
     return str->cap;
 }
@@ -175,7 +175,7 @@ bool dsbuf_append_str(DSBuffer *str, const char *newstr) {
     return true;
 }
 
-int dsbuf_char_at(DSBuffer *str, size_t pos) {
+int dsbuf_char_at(const DSBuffer *str, size_t pos) {
     if ((!str) || (pos >= str->len)) {
         return DSBUFFER_CHAR_NOT_FOUND;
     }
@@ -183,7 +183,7 @@ int dsbuf_char_at(DSBuffer *str, size_t pos) {
     return str->str[pos];
 }
 
-DSBuffer * dsbuf_substr(DSBuffer *str, size_t start, size_t len) {
+DSBuffer *dsbuf_substr(const DSBuffer *str, size_t start, size_t len) {
     if ((!str) || (start > str->len) || (len > (str->len - start))) {
         return NULL;
     }
@@ -198,7 +198,7 @@ DSBuffer * dsbuf_substr(DSBuffer *str, size_t start, size_t len) {
     return sub;
 }
 
-bool dsbuf_equals(DSBuffer *str, DSBuffer *other) {
+bool dsbuf_equals(const DSBuffer *str, const DSBuffer *other) {
     if ((!str) || (!other)) {
         return false;
     }
@@ -215,13 +215,13 @@ bool dsbuf_equals(DSBuffer *str, DSBuffer *other) {
     return (res == 0);
 }
 
-bool dsbuf_equals_char(DSBuffer *str, const char *other) {
+bool dsbuf_equals_char(const DSBuffer *str, const char *other) {
     if (!str) { return false; }
     int res = strcmp(str->str, other);
     return (res == 0);
 }
 
-const char* dsbuf_char_ptr(DSBuffer *str) {
+const char *dsbuf_char_ptr(const DSBuffer *str) {
     if (!str) {
         return NULL;
     }
@@ -229,29 +229,28 @@ const char* dsbuf_char_ptr(DSBuffer *str) {
     return str->str;
 }
 
-char* dsbuf_to_char_array(DSBuffer *str) {
+char *dsbuf_to_char_array(const DSBuffer *str) {
     if (!str) {
         return NULL;
     }
 
     size_t m = (str->len) + 1;
-    char* cpy = calloc(m, m);
+    char* cpy = malloc(m);
     if (!cpy) {
         return NULL;
     }
 
-    /* Use strncpy here since we can only return a C-string (NUL terminated),
-     * rather than memcpy like the rest of the gbuf functions */
-    strncpy(cpy, str->str, str->len);
+    memcpy(cpy, str->str, str->len);
+    str->str[str->len] = '\0';
     return cpy;
 }
 
-unsigned int dsbuf_hash(DSBuffer *str) {
+unsigned int dsbuf_hash(const DSBuffer *str) {
     if (!str) { return 0; }
     return (unsigned int) hash_fnv1(str->str);
 }
 
-int dsbuf_compare(DSBuffer *left, DSBuffer *right) {
+int dsbuf_compare(const DSBuffer *left, const DSBuffer *right) {
     if (!left) { return INT_MIN; }
     if (!right) { return INT_MAX; }
     if (left->len < right->len) { return -1; }
@@ -259,7 +258,7 @@ int dsbuf_compare(DSBuffer *left, DSBuffer *right) {
     return memcmp(left->str, right->str, left->len);
 }
 
-bool dsbuf_utf8_validate(DSBuffer *buf, size_t *l) {
+bool dsbuf_utf8_validate(const DSBuffer *buf, size_t *l) {
     if (!buf) { return false; }
 
     bool count = (l != NULL) ? true : false;
@@ -277,7 +276,7 @@ bool dsbuf_utf8_validate(DSBuffer *buf, size_t *l) {
     return true;
 }
 
-size_t dsbuf_utf8_len(DSBuffer *buf) {
+size_t dsbuf_utf8_len(const DSBuffer *buf) {
     if (!buf) { return 0; }
 
     const char *s = buf->str;

--- a/deps/libds/buffer.h
+++ b/deps/libds/buffer.h
@@ -93,6 +93,15 @@ DSBuffer *dsbuf_new_buffer(size_t cap);
 void dsbuf_destroy(DSBuffer *str);
 
 /**
+* @brief Duplicate a @c DSBuffer object
+*
+* @param str a @c DSBuffer object to copy
+* @returns a copy of the given @c DSBuffer object or NULL if a copy could
+*          not be made for some reason (e.g. memory allocation issues)
+*/
+DSBuffer *dsbuf_dup(const DSBuffer *str);
+
+/**
 * @brief Return the length in number of bytes in the @c DSBuffer.
 *
 * Note that this is not the UTF-8 length.

--- a/deps/libds/buffer.h
+++ b/deps/libds/buffer.h
@@ -25,12 +25,12 @@ typedef struct DSBuffer DSBuffer;
 /**
 * @brief The factor by which a @c DSBuffer is resized when needed
 */
-static const int DSBUFFER_CAPACITY_FACTOR = 2;
+static const size_t DSBUFFER_CAPACITY_FACTOR = 2;
 
 /**
 * @brief The minimum size of a @c DSBuffer.
 */
-static const int DSBUFFER_MINIMUM_CAPACITY = 20;
+static const size_t DSBUFFER_MINIMUM_CAPACITY = 20;
 
 /**
 * @brief Error codes for @c DSBuffer functions.
@@ -109,7 +109,7 @@ DSBuffer *dsbuf_dup(const DSBuffer *str);
 * @param str a @c DSBuffer object
 * @returns the number of used bytes in @c str
 */
-size_t dsbuf_len(DSBuffer *str);
+size_t dsbuf_len(const DSBuffer *str);
 
 /**
 * @brief Return the capacity in number of bytes in the @c DSBuffer.
@@ -117,7 +117,7 @@ size_t dsbuf_len(DSBuffer *str);
 * @param str a @c DSBuffer object
 * @returns the number of available bytes in @c str
 */
-size_t dsbuf_cap(DSBuffer *str);
+size_t dsbuf_cap(const DSBuffer *str);
 
 /**
 * @brief Append @c newc to @c str, resizing @c str if necessary.
@@ -169,7 +169,7 @@ bool dsbuf_append_str(DSBuffer *str, const char *newstr);
 * @returns @c DSBUFFER_CHAR_NOT_FOUND if the position is greater than or
 *          equal to the length of the string or is 0; the character otherwise
 */
-int dsbuf_char_at(DSBuffer *str, size_t pos);
+int dsbuf_char_at(const DSBuffer *str, size_t pos);
 
 /**
 * @brief Return a substring of the given buffer.
@@ -184,7 +184,7 @@ int dsbuf_char_at(DSBuffer *str, size_t pos);
 *          the length would exceed the length of the string or memory could
 *          not be allocated; the substring as a @c DSBuffer otherwise
 */
-DSBuffer* dsbuf_substr(DSBuffer *str, size_t start, size_t len);
+DSBuffer *dsbuf_substr(const DSBuffer *str, size_t start, size_t len);
 
 /**
 * @brief Check if two @c DSBuffer objects are equal (but not the same).
@@ -196,7 +196,7 @@ DSBuffer* dsbuf_substr(DSBuffer *str, size_t start, size_t len);
 * @param other another @c DSBuffer object
 * @returns @c true if @c str is equal to @c other
 */
-bool dsbuf_equals(DSBuffer *str, DSBuffer *other);
+bool dsbuf_equals(const DSBuffer *str, const DSBuffer *other);
 
 /**
 * @brief Check if the internal buffer of a @c DSBuffer is equal to a standard
@@ -206,7 +206,7 @@ bool dsbuf_equals(DSBuffer *str, DSBuffer *other);
 * @param other a standard C string
 * @returns @c true if the internal buffer of @c str is binary equal to @c other
 */
-bool dsbuf_equals_char(DSBuffer *str, const char *other);
+bool dsbuf_equals_char(const DSBuffer *str, const char *other);
 
 /**
 * @brief Return the pointer to the internal character array.
@@ -218,7 +218,7 @@ bool dsbuf_equals_char(DSBuffer *str, const char *other);
 * @param str a @c DSBuffer object
 * @returns a pointer to the internal character buffer
 */
-const char* dsbuf_char_ptr(DSBuffer *str);
+const char *dsbuf_char_ptr(const DSBuffer *str);
 
 /**
 * @brief Return a @c char array corresponding to the underlying string.
@@ -232,7 +232,7 @@ const char* dsbuf_char_ptr(DSBuffer *str);
 * @returns a copy of the internal buffer as a C string up to the first
 *          @c NUL byte
 */
-char* dsbuf_to_char_array(DSBuffer *str);
+char *dsbuf_to_char_array(const DSBuffer *str);
 
 /**
 * @brief Return a hash of the underlying string.
@@ -243,7 +243,7 @@ char* dsbuf_to_char_array(DSBuffer *str);
 * @param str a @c DSBuffer object
 * @returns a hash of the internal buffer
 */
-unsigned int dsbuf_hash(DSBuffer *str);
+unsigned int dsbuf_hash(const DSBuffer *str);
 
 /**
 * @brief Compare two DSBuffers.
@@ -257,7 +257,7 @@ unsigned int dsbuf_hash(DSBuffer *str);
 *          @c right is shorter than @c left; 0 if the two strings are the
 *          same length and equal
 */
-int dsbuf_compare(DSBuffer *left, DSBuffer *right);
+int dsbuf_compare(const DSBuffer *left, const DSBuffer *right);
 
 /*
 * @brief Check if the internal buffer contains a valid UTF-8 sequence.
@@ -266,7 +266,7 @@ int dsbuf_compare(DSBuffer *left, DSBuffer *right);
 * @param l output the length in UTF-8 characters; use @c NULL to ignore
 * @returns @c true if the buffer is valid UTF-8; @c false otherwise
 */
-bool dsbuf_utf8_validate(DSBuffer *buf, size_t *l);
+bool dsbuf_utf8_validate(const DSBuffer *buf, size_t *l);
 
 /*
 * @brief Return the length of the string in UTF-8 characters.
@@ -280,6 +280,6 @@ bool dsbuf_utf8_validate(DSBuffer *buf, size_t *l);
 * @param buf a @c DSBuffer object
 * @returns 0 if @c buf is @c NULL; the length in UTF-8 characters otherwise
 */
-size_t dsbuf_utf8_len(DSBuffer *buf);
+size_t dsbuf_utf8_len(const DSBuffer *buf);
 
 #endif //LIBDS_BUFFER_H

--- a/deps/libds/dict.c
+++ b/deps/libds/dict.c
@@ -56,7 +56,7 @@ static inline size_t compute_index(uint32_t hash, size_t cap);
  * DICTIONARY PUBLIC FUNCTIONS
  */
 
-DSDict * dsdict_new(dsdict_hash_fn hash, dsdict_compare_fn cmpfn, dsdict_free_fn keyfree, dsdict_free_fn valfree) {
+DSDict *dsdict_new(dsdict_hash_fn hash, dsdict_compare_fn cmpfn, dsdict_free_fn keyfree, dsdict_free_fn valfree) {
     if ((!hash) || (!cmpfn)) { return NULL; }
 
     DSDict *dict = malloc(sizeof(DSDict));
@@ -64,8 +64,8 @@ DSDict * dsdict_new(dsdict_hash_fn hash, dsdict_compare_fn cmpfn, dsdict_free_fn
         return NULL;
     }
 
-    size_t cap = sizeof(struct bucket *) * DSDICT_DEFAULT_CAP;
-    dict->vals = calloc(cap, sizeof(struct bucket *));
+    size_t cap = DSDICT_DEFAULT_CAP;
+    dict->vals = calloc(cap, sizeof(struct bucket));
     if (!dict->vals) {
         free(dict);
         return NULL;
@@ -87,12 +87,12 @@ void dsdict_destroy(DSDict *dict) {
     free(dict);
 }
 
-size_t dsdict_count(DSDict *dict) {
+size_t dsdict_count(const DSDict *dict) {
     assert(dict);
     return dict->cnt;
 }
 
-size_t dsdict_cap(DSDict *dict) {
+size_t dsdict_cap(const DSDict *dict) {
     assert(dict);
     return dict->cap;
 }
@@ -174,7 +174,7 @@ cleanup_dsdict_put: {
     return;
 }
 
-void* dsdict_get(DSDict *dict, void *key) {
+void *dsdict_get(const DSDict *dict, void *key) {
     if ((!dict) || (!key)) { return NULL; }
 
     unsigned int hash = dict->hash(key);
@@ -197,7 +197,7 @@ void* dsdict_get(DSDict *dict, void *key) {
     return NULL;
 }
 
-void* dsdict_del(DSDict *dict, void *key) {
+void *dsdict_del(DSDict *dict, void *key) {
     if ((!dict) || (!key)) { return NULL; }
 
     unsigned int hash = dict->hash(key);

--- a/deps/libds/dict.h
+++ b/deps/libds/dict.h
@@ -58,7 +58,7 @@ typedef void (*dsdict_foreach_fn)(const void*, void*);
 * @returns a new @c DSDict object or @c NULL if no hash function is
 *          specified or memory could not be allocated
 */
-DSDict* dsdict_new(dsdict_hash_fn hash, dsdict_compare_fn cmpfn, dsdict_free_fn keyfree, dsdict_free_fn valfree);
+DSDict *dsdict_new(dsdict_hash_fn hash, dsdict_compare_fn cmpfn, dsdict_free_fn keyfree, dsdict_free_fn valfree);
 
 /**
 * @brief Destroy a @c DSDict object.
@@ -77,7 +77,7 @@ void dsdict_destroy(DSDict *dict);
 * @param dict a @c DSDict object
 * @returns the number of elements in @c dict
 */
-size_t dsdict_count(DSDict *dict);
+size_t dsdict_count(const DSDict *dict);
 
 /**
 * @brief Return the capacity of this collection.
@@ -90,7 +90,7 @@ size_t dsdict_count(DSDict *dict);
 * @param dict a @c DSDict object
 * @returns the number of elements that @c dict can hold
 */
-size_t dsdict_cap(DSDict *dict);
+size_t dsdict_cap(const DSDict *dict);
 
 /**
 * @brief Perform the given function on each object in the dictionary.
@@ -109,7 +109,7 @@ void dsdict_foreach(DSDict *dict, dsdict_foreach_fn func);
 /**
  * @brief Create a new @c DSIter object for this dictionary.
  */
-DSIter* dsdict_iter(DSDict *dict);
+DSIter *dsdict_iter(DSDict *dict);
 
 /**
 * @brief Put the given element in the dictionary by key.
@@ -137,7 +137,7 @@ void dsdict_put(DSDict *dict, void *key, void *val);
 * @returns @c NULL if the element does not exist in the dictionary;
 *          the element otherwise
 */
-void* dsdict_get(DSDict *dict, void *key);
+void *dsdict_get(const DSDict *dict, void *key);
 
 /**
 * @brief Remove the element from the dictionary and return it to the caller.
@@ -149,6 +149,6 @@ void* dsdict_get(DSDict *dict, void *key);
 * @returns @c NULL if the element does not exist in the dictionary;
 *          the element otherwise
 */
-void* dsdict_del(DSDict *dict, void *key);
+void *dsdict_del(DSDict *dict, void *key);
 
 #endif //LIBDS_DICT_H

--- a/deps/libds/iter.c
+++ b/deps/libds/iter.c
@@ -51,7 +51,7 @@ bool dsiter_has_next(DSIter *iter) {
     return false;
 }
 
-void* dsiter_key(DSIter *iter) {
+void *dsiter_key(DSIter *iter) {
     if (!iter) { return NULL; }
 
     switch(iter->type) {
@@ -66,7 +66,7 @@ void* dsiter_key(DSIter *iter) {
     return NULL;
 }
 
-void* dsiter_value(DSIter *iter) {
+void *dsiter_value(DSIter *iter) {
     if (!iter) { return NULL; }
 
     switch(iter->type) {
@@ -81,7 +81,7 @@ void* dsiter_value(DSIter *iter) {
     return NULL;
 }
 
-size_t dsiter_index(DSIter *iter) {
+size_t dsiter_index(const DSIter *iter) {
     if (!iter) { return SIZE_MAX; }
     return iter->cur;
 }

--- a/deps/libds/iter.h
+++ b/deps/libds/iter.h
@@ -59,7 +59,7 @@ bool dsiter_has_next(DSIter *iter);
 * @returns the current key if @c dsiter_next returned @c true; @c false
 *          otherwise
 */
-void* dsiter_key(DSIter *iter);
+void *dsiter_key(DSIter *iter);
 
 /**
 * @brief Return the current value.
@@ -72,7 +72,7 @@ void* dsiter_key(DSIter *iter);
 * @param iter a @c DSIter object
 * @returns the value associated with the current element pointer
 */
-void* dsiter_value(DSIter *iter);
+void *dsiter_value(DSIter *iter);
 
 /**
 * @brief Return the current enumerated index for the current element.
@@ -85,7 +85,7 @@ void* dsiter_value(DSIter *iter);
 * @param iter a @c DSIter object
 * @returns the enumerated index of the current iteration
 */
-size_t dsiter_index(DSIter *iter);
+size_t dsiter_index(const DSIter *iter);
 
 /**
 * @brief Reset a @c DSIter object to a new state.

--- a/deps/libds/list.c
+++ b/deps/libds/list.c
@@ -50,12 +50,12 @@ void dslist_destroy(DSList *list) {
     free(list);
 }
 
-size_t dslist_len(DSList *list) {
+size_t dslist_len(const DSList *list) {
     assert(list);
     return list->len;
 }
 
-void* dslist_get(DSList *list, size_t index) {
+void *dslist_get(const DSList *list, size_t index) {
     if ((!list) || (index >= list->len)) {
         return NULL;
     }
@@ -158,7 +158,7 @@ bool dslist_insert(DSList *list, void *elem, size_t index){
     return false;
 }
 
-void* dslist_remove(DSList *list, void *elem){
+void *dslist_remove(DSList *list, void *elem){
     if ((!list) || (!elem)) { return NULL; }
     if (!list->cmp) { return NULL; }
 
@@ -173,7 +173,7 @@ void* dslist_remove(DSList *list, void *elem){
     return NULL;
 }
 
-void* dslist_remove_index(DSList *list, size_t index){
+void *dslist_remove_index(DSList *list, size_t index){
     if (!list) { return NULL; }
     if (index >= list->len) { return NULL; }
 
@@ -194,7 +194,7 @@ bool dslist_enqueue(DSList *list, void *elem){
     return (list) ? dslist_insert(list, elem, list->len) : false;
 }
 
-void* dslist_dequeue(DSList *list){
+void *dslist_dequeue(DSList *list){
     if ((!list) || (list->len < 1)) { return NULL; }
 
     // Point the list header to the next node
@@ -214,7 +214,7 @@ void* dslist_dequeue(DSList *list){
     return data;
 }
 
-void* dslist_pop(DSList *list){
+void *dslist_pop(DSList *list){
     if ((!list) || (list->len < 1)) { return NULL; }
 
     // Point the list footer to the previous node

--- a/deps/libds/list.h
+++ b/deps/libds/list.h
@@ -69,7 +69,7 @@ void dslist_destroy(DSList *list);
 * @param list a @c DSList object
 * @returns the number of elements in @c list
 */
-size_t dslist_len(DSList *list);
+size_t dslist_len(const DSList *list);
 
 /**
 * @brief Return the object stored at the given index.
@@ -79,7 +79,7 @@ size_t dslist_len(DSList *list);
 * @returns @c NULL if the index has no element or is invalid; the
 *          object otherwise
 */
-void* dslist_get(DSList *list, size_t index);
+void *dslist_get(const DSList *list, size_t index);
 
 /**
 * @brief Perform the given function on each object in the list.
@@ -141,7 +141,7 @@ bool dslist_insert(DSList *list, void *elem, size_t index);
 * @returns a pointer to the element or @c NULL if the element cannot be
 *          found or no comparator function was specified
 */
-void* dslist_remove(DSList *list, void *elem);
+void *dslist_remove(DSList *list, void *elem);
 
 /**
 * @brief Remove the element at the given index and return it.
@@ -154,7 +154,7 @@ void* dslist_remove(DSList *list, void *elem);
 *          found or no comparator function was specified or the index was
 *          invalid
 */
-void* dslist_remove_index(DSList *list, size_t index);
+void *dslist_remove_index(DSList *list, size_t index);
 
 /**
 * @brief Enqueue the given element in the list.
@@ -175,7 +175,7 @@ bool dslist_enqueue(DSList *list, void *elem);
 * @returns @c NULL if the list is empty; a pointer to the head element
 *          otherwise
 */
-void* dslist_dequeue(DSList *list);
+void *dslist_dequeue(DSList *list);
 
 /**
 * @brief Pop the top (foot) element from the list.
@@ -185,7 +185,7 @@ void* dslist_dequeue(DSList *list);
 * @param list a @c DSList object
 * @returns a pointer to the top element or @c NULL if the list is empty
 */
-void* dslist_pop(DSList *list);
+void *dslist_pop(DSList *list);
 
 /**
 * @brief Clear the entire list, freeing elements as they are removed.

--- a/src/bytecode.c
+++ b/src/bytecode.c
@@ -73,13 +73,13 @@ static void ExprToOpCodes(ms_Expr *expr, DSArray *opcodes, DSArray *values, DSAr
     assert(values);
 
     if (expr->type == EXPRTYPE_UNARY) {
-        ExprComponentToOpCodes(&expr->expr.u->expr, expr->expr.u->type,
+        ExprComponentToOpCodes(&expr->cmpnt.u->atom, expr->cmpnt.u->type,
                                opcodes, values, idents);
         ExprOpToOpCode(expr, opcodes);
     } else {
-        ExprComponentToOpCodes(&expr->expr.b->left, expr->expr.b->ltype,
+        ExprComponentToOpCodes(&expr->cmpnt.b->latom, expr->cmpnt.b->ltype,
                                opcodes, values, idents);
-        ExprComponentToOpCodes(&expr->expr.b->right, expr->expr.b->rtype,
+        ExprComponentToOpCodes(&expr->cmpnt.b->ratom, expr->cmpnt.b->rtype,
                                opcodes, values, idents);
         ExprOpToOpCode(expr, opcodes);
     }
@@ -152,7 +152,7 @@ static void ExprOpToOpCode(ms_Expr *expr, DSArray *opcodes) {
     if (!o) { return; }
 
     if (expr->type == EXPRTYPE_BINARY) {
-        switch (expr->expr.b->op) {
+        switch (expr->cmpnt.b->op) {
             case BINARY_PLUS:
                 *o = OPC_ADD;
                 break;
@@ -223,7 +223,7 @@ static void ExprOpToOpCode(ms_Expr *expr, DSArray *opcodes) {
 
         dsarray_append(opcodes, o);
     } else {
-        switch (expr->expr.u->op) {
+        switch (expr->cmpnt.u->op) {
             case UNARY_MINUS:
                 *o = OPC_NEGATE;
                 break;

--- a/src/bytecode.c
+++ b/src/bytecode.c
@@ -77,11 +77,19 @@ static void ExprToOpCodes(ms_Expr *expr, DSArray *opcodes, DSArray *values, DSAr
                                opcodes, values, idents);
         ExprOpToOpCode(expr, opcodes);
     } else {
-        ExprComponentToOpCodes(&expr->cmpnt.b->latom, expr->cmpnt.b->ltype,
-                               opcodes, values, idents);
-        ExprComponentToOpCodes(&expr->cmpnt.b->ratom, expr->cmpnt.b->rtype,
-                               opcodes, values, idents);
-        ExprOpToOpCode(expr, opcodes);
+        if (expr->cmpnt.b->op == BINARY_CALL) {
+            ExprComponentToOpCodes(&expr->cmpnt.b->ratom, expr->cmpnt.b->rtype,
+                                   opcodes, values, idents);
+            ExprComponentToOpCodes(&expr->cmpnt.b->latom, expr->cmpnt.b->ltype,
+                                   opcodes, values, idents);
+            ExprOpToOpCode(expr, opcodes);
+        } else {
+            ExprComponentToOpCodes(&expr->cmpnt.b->latom, expr->cmpnt.b->ltype,
+                                   opcodes, values, idents);
+            ExprComponentToOpCodes(&expr->cmpnt.b->ratom, expr->cmpnt.b->rtype,
+                                   opcodes, values, idents);
+            ExprOpToOpCode(expr, opcodes);
+        }
     }
 }
 

--- a/src/bytecode.c
+++ b/src/bytecode.c
@@ -1,0 +1,243 @@
+/*------------------------------------------------------------------------------
+ *    Copyright 2016 Chris Rink
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *----------------------------------------------------------------------------*/
+
+#include <assert.h>
+#include <limits.h>
+#include "bytecode.h"
+#include "vm.h"
+
+static const int EXPR_OPCODE_STACK_LEN = 50;
+static const int EXPR_VALUE_STACK_LEN = 50;
+static const int EXPR_IDENT_STACK_LEN = 50;
+
+static void ExprToOpCodes(ms_Expr *expr, DSArray *opcodes, DSArray *values, DSArray *idents);
+static void ExprComponentToOpCodes(ms_ExprAtom *a, ms_ExprAtomType type, DSArray *opcodes, DSArray *values, DSArray *idents);
+static void ExprOpToOpCode(ms_Expr *expr, DSArray *opcodes);
+
+/*
+ * PUBLIC FUNCTIONS
+ */
+
+ms_VMByteCode *ms_ExprToOpCodes(ms_Expr *expr) {
+    if (!expr) { return NULL; }
+
+    DSArray *opcodes = dsarray_new_cap(EXPR_OPCODE_STACK_LEN, NULL,
+                                       (dsarray_free_fn)free);
+    if (!opcodes) {
+        return NULL;
+    }
+
+    DSArray *values = dsarray_new_cap(EXPR_VALUE_STACK_LEN, NULL,
+                                      (dsarray_free_fn)free);
+    if (!values) {
+        dsarray_destroy(opcodes);
+        return NULL;
+    }
+
+    /* no dsarray_free_fn required since we pass the pointer to the bytecode */
+    DSArray *idents = dsarray_new_cap(EXPR_IDENT_STACK_LEN, NULL, NULL);
+    if (!idents) {
+        dsarray_destroy(values);
+        dsarray_destroy(opcodes);
+        return NULL;
+    }
+
+    ExprToOpCodes(expr, opcodes, values, idents);
+    ms_VMByteCode *bc = ms_VMByteCodeNew(opcodes, values, idents);
+    dsarray_destroy(opcodes);
+    dsarray_destroy(values);
+    dsarray_destroy(idents);
+    return bc;
+}
+
+/*
+ * PRIVATE FUNCTIONS
+ */
+
+static void ExprToOpCodes(ms_Expr *expr, DSArray *opcodes, DSArray *values, DSArray *idents) {
+    assert(expr);
+    assert(opcodes);
+    assert(values);
+
+    if (expr->type == EXPRTYPE_UNARY) {
+        ExprComponentToOpCodes(&expr->expr.u->expr, expr->expr.u->type,
+                               opcodes, values, idents);
+        ExprOpToOpCode(expr, opcodes);
+    } else {
+        ExprComponentToOpCodes(&expr->expr.b->left, expr->expr.b->ltype,
+                               opcodes, values, idents);
+        ExprComponentToOpCodes(&expr->expr.b->right, expr->expr.b->rtype,
+                               opcodes, values, idents);
+        ExprOpToOpCode(expr, opcodes);
+    }
+}
+
+static void ExprComponentToOpCodes(ms_ExprAtom *a, ms_ExprAtomType type, DSArray *opcodes, DSArray *values, DSArray *idents) {
+    assert(a);
+    assert(opcodes);
+    assert(values);
+
+    switch (type) {
+        case EXPRATOM_EXPRESSION: {
+            ExprToOpCodes(a->expr, opcodes, values, idents);
+            break;
+        }
+        case EXPRATOM_VALUE: {
+            ms_VMOpCode *o = malloc(sizeof(ms_VMOpCode));
+            if (!o) { return; }
+
+            ms_Value *v = malloc(sizeof(ms_Value));
+            if (!v) {
+                free(o);
+                return;
+            }
+
+            *v = a->val;
+
+            dsarray_append(values, v);
+            size_t nvals = dsarray_len(values);
+            assert(nvals <= INT_MAX);
+            *o = ms_VMOpCodeWithArg(OPC_PUSH, (int)(nvals - 1));
+            dsarray_append(opcodes, o);
+            break;
+        }
+        case EXPRATOM_IDENT: {
+            ms_VMOpCode *o = malloc(sizeof(ms_VMOpCode));
+            if (!o) { return; }
+
+            ms_Ident *id = dsbuf_dup(a->ident);
+            if (!id) {
+                free(o);
+                return;
+            }
+
+            dsarray_append(idents, id);
+            size_t nidents = dsarray_len(idents);
+            assert(nidents <= INT_MAX);
+            *o = ms_VMOpCodeWithArg(OPC_LOAD_NAME, (int)(nidents - 1));
+            dsarray_append(opcodes, o);
+            break;
+        }
+        case EXPRATOM_EXPRLIST: {
+            size_t len = dsarray_len(a->list);
+            for (size_t i = 0; i < len; i++) {
+                ms_Expr *expr = dsarray_get(a->list, i);
+                ExprToOpCodes(expr, opcodes, values, idents);
+            }
+            break;
+        }
+        case EXPRATOM_EMPTY:
+            assert(false);
+    }
+}
+
+static void ExprOpToOpCode(ms_Expr *expr, DSArray *opcodes) {
+    assert(expr);
+    assert(opcodes);
+
+    ms_VMOpCode *o = malloc(sizeof(ms_VMOpCode));
+    if (!o) { return; }
+
+    if (expr->type == EXPRTYPE_BINARY) {
+        switch (expr->expr.b->op) {
+            case BINARY_PLUS:
+                *o = OPC_ADD;
+                break;
+            case BINARY_MINUS:
+                *o = OPC_SUBTRACT;
+                break;
+            case BINARY_TIMES:
+                *o = OPC_MULTIPLY;
+                break;
+            case BINARY_DIVIDE:
+                *o = OPC_DIVIDE;
+                break;
+            case BINARY_IDIVIDE:
+                *o = OPC_IDIVIDE;
+                break;
+            case BINARY_MODULO:
+                *o = OPC_MODULO;
+                break;
+            case BINARY_EXPONENTIATE:
+                *o = OPC_EXPONENTIATE;
+                break;
+            case BINARY_SHIFT_LEFT:
+                *o = OPC_SHIFT_LEFT;
+                break;
+            case BINARY_SHIFT_RIGHT:
+                *o = OPC_SHIFT_RIGHT;
+                break;
+            case BINARY_BITWISE_AND:
+                *o = OPC_BITWISE_AND;
+                break;
+            case BINARY_BITWISE_XOR:
+                *o = OPC_BITWISE_XOR;
+                break;
+            case BINARY_BITWISE_OR:
+                *o = OPC_BITWISE_OR;
+                break;
+            case BINARY_LE:
+                *o = OPC_LE;
+                break;
+            case BINARY_LT:
+                *o = OPC_LT;
+                break;
+            case BINARY_GE:
+                *o = OPC_GE;
+                break;
+            case BINARY_GT:
+                *o = OPC_GT;
+                break;
+            case BINARY_EQ:
+                *o = OPC_EQ;
+                break;
+            case BINARY_NOT_EQ:
+                *o = OPC_NOT_EQ;
+                break;
+            case BINARY_AND:
+                *o = OPC_AND;
+                break;
+            case BINARY_OR:
+                *o = OPC_OR;
+                break;
+            case BINARY_CALL:
+                *o = OPC_CALL;
+                break;
+            default:
+                free(o);
+                return;
+        }
+
+        dsarray_append(opcodes, o);
+    } else {
+        switch (expr->expr.u->op) {
+            case UNARY_MINUS:
+                *o = OPC_NEGATE;
+                break;
+            case UNARY_NOT:
+                *o = OPC_NOT;
+                break;
+            case UNARY_BITWISE_NOT:
+                *o = OPC_BITWISE_NOT;
+                break;
+            default:
+                free(o);
+                return;
+        }
+
+        dsarray_append(opcodes, o);
+    }
+}

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -1,0 +1,80 @@
+/*------------------------------------------------------------------------------
+ *    Copyright 2016 Chris Rink
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *----------------------------------------------------------------------------*/
+
+#ifndef MSCRIPT_BYTECODE_H
+#define MSCRIPT_BYTECODE_H
+
+#include <stddef.h>
+#include "lang.h"
+
+/**
+* @brief Enumeration of mscript VM opcodes
+*/
+typedef enum {
+    OPC_PRINT,
+    OPC_PUSH,
+    OPC_POP,
+    OPC_SWAP,
+    OPC_ADD,
+    OPC_SUBTRACT,
+    OPC_MULTIPLY,
+    OPC_DIVIDE,
+    OPC_IDIVIDE,
+    OPC_MODULO,
+    OPC_EXPONENTIATE,
+    OPC_NEGATE,
+    OPC_SHIFT_LEFT,
+    OPC_SHIFT_RIGHT,
+    OPC_BITWISE_AND,
+    OPC_BITWISE_XOR,
+    OPC_BITWISE_OR,
+    OPC_BITWISE_NOT,
+    OPC_LE,
+    OPC_LT,
+    OPC_GE,
+    OPC_GT,
+    OPC_EQ,
+    OPC_NOT_EQ,
+    OPC_NOT,
+    OPC_AND,
+    OPC_OR,
+    OPC_CALL,
+    OPC_LOAD_NAME,
+} ms_VMOpCodeType;
+
+/**
+* @brief Opcode value
+*/
+typedef int ms_VMOpCode;
+
+/**
+* @brief Container for a full mscript bytecode script
+*/
+typedef struct {
+    ms_VMOpCode *code;                              /* array of opcodes */
+    ms_Value *values;                               /* array of VM values */
+    ms_Ident **idents;                              /* array of identifiers */
+    size_t nops;                                    /* number of opcodes */
+    size_t nvals;                                   /* number of values */
+    size_t nidents;                                 /* number of idents */
+} ms_VMByteCode;
+
+/**
+* @brief Generate mscript VM bytecode from the given expression value.
+*/
+ms_VMByteCode *ms_ExprToOpCodes(ms_Expr *expr);
+
+#endif //MSCRIPT_BYTECODE_H

--- a/src/lang.c
+++ b/src/lang.c
@@ -315,41 +315,6 @@ void ms_ExprDestroy(ms_Expr *expr) {
     free(expr);
 }
 
-ms_ExprBinaryOp ms_ExprTokenToBinaryOp(ms_TokenType type) {
-    switch (type) {
-        case OP_PLUS:           return BINARY_PLUS;
-        case OP_MINUS:          return BINARY_MINUS;
-        case OP_TIMES:          return BINARY_TIMES;
-        case OP_DIVIDE:         return BINARY_DIVIDE;
-        case OP_IDIVIDE:        return BINARY_IDIVIDE;
-        case OP_MODULO:         return BINARY_MODULO;
-        case OP_EXPONENTIATE:   return BINARY_EXPONENTIATE;
-        case OP_SHIFT_LEFT:     return BINARY_SHIFT_LEFT;
-        case OP_SHIFT_RIGHT:    return BINARY_SHIFT_RIGHT;
-        case OP_BITWISE_AND:    return BINARY_BITWISE_AND;
-        case OP_BITWISE_XOR:    return BINARY_BITWISE_XOR;
-        case OP_BITWISE_OR:     return BINARY_BITWISE_OR;
-        case OP_LE:             return BINARY_LE;
-        case OP_LT:             return BINARY_LT;
-        case OP_GE:             return BINARY_GE;
-        case OP_GT:             return BINARY_GT;
-        case OP_DOUBLE_EQ:      return BINARY_EQ;
-        case OP_NOT_EQ:         return BINARY_NOT_EQ;
-        case OP_AND:            return BINARY_AND;
-        case OP_OR:             return BINARY_OR;
-        default:                return BINARY_EMPTY;
-    }
-}
-
-ms_ExprUnaryOp ms_ExprTokenToUnaryOp(ms_TokenType type) {
-    switch (type) {
-        case OP_UMINUS:         return UNARY_MINUS;
-        case OP_NOT:            return UNARY_NOT;
-        case OP_BITWISE_NOT:    return UNARY_BITWISE_NOT;
-        default:                return UNARY_NONE;
-    }
-}
-
 /*
  * PRIVATE FUNCTIONS
  */

--- a/src/lang.c
+++ b/src/lang.c
@@ -34,25 +34,25 @@ ms_Expr *ms_ExprNew(ms_ExprType type) {
     expr->type = type;
     switch (type) {
         case EXPRTYPE_UNARY:
-            expr->expr.u = malloc(sizeof(ms_ExprUnary));
-            if (!expr->expr.u) {
+            expr->cmpnt.u = malloc(sizeof(ms_ExprUnary));
+            if (!expr->cmpnt.u) {
                 free(expr);
                 return NULL;
             }
-            expr->expr.u->expr.expr = NULL;
-            expr->expr.u->op = UNARY_NONE;
+            expr->cmpnt.u->atom.expr = NULL;
+            expr->cmpnt.u->op = UNARY_NONE;
             break;
         case EXPRTYPE_BINARY:
-            expr->expr.b = malloc(sizeof(ms_ExprBinary));
-            if (!expr->expr.b) {
+            expr->cmpnt.b = malloc(sizeof(ms_ExprBinary));
+            if (!expr->cmpnt.b) {
                 free(expr);
                 return NULL;
             }
-            expr->expr.b->left.expr = NULL;
-            expr->expr.b->ltype = EXPRATOM_EMPTY;
-            expr->expr.b->op = BINARY_EMPTY;
-            expr->expr.b->rtype = EXPRATOM_EMPTY;
-            expr->expr.b->right.expr = NULL;
+            expr->cmpnt.b->latom.expr = NULL;
+            expr->cmpnt.b->ltype = EXPRATOM_EMPTY;
+            expr->cmpnt.b->op = BINARY_EMPTY;
+            expr->cmpnt.b->rtype = EXPRATOM_EMPTY;
+            expr->cmpnt.b->ratom.expr = NULL;
             break;
     }
 
@@ -65,10 +65,10 @@ ms_Expr *ms_ExprNewWithVal(ms_ValDataType type, ms_ValData v) {
         return NULL;
     }
 
-    expr->expr.u->expr.val.type = type;
-    expr->expr.u->expr.val.val = v;
-    expr->expr.u->type = EXPRATOM_VALUE;
-    expr->expr.u->op = UNARY_NONE;
+    expr->cmpnt.u->atom.val.type = type;
+    expr->cmpnt.u->atom.val.val = v;
+    expr->cmpnt.u->type = EXPRATOM_VALUE;
+    expr->cmpnt.u->op = UNARY_NONE;
     return expr;
 }
 
@@ -78,14 +78,14 @@ ms_Expr *ms_ExprNewWithIdent(const char *name, size_t len) {
         return NULL;
     }
 
-    expr->expr.u->expr.ident = dsbuf_new_l(name, len);
-    if (!expr->expr.u->expr.ident) {
+    expr->cmpnt.u->atom.ident = dsbuf_new_l(name, len);
+    if (!expr->cmpnt.u->atom.ident) {
         free(expr);
         return NULL;
     }
 
-    expr->expr.u->type = EXPRATOM_IDENT;
-    expr->expr.u->op = UNARY_NONE;
+    expr->cmpnt.u->type = EXPRATOM_IDENT;
+    expr->cmpnt.u->op = UNARY_NONE;
     return expr;
 }
 
@@ -99,9 +99,9 @@ ms_Expr *ms_ExprNewWithList(ms_ExprList *list) {
         return NULL;
     }
 
-    expr->expr.u->expr.list = list;
-    expr->expr.u->type = EXPRATOM_EXPRLIST;
-    expr->expr.u->op = UNARY_NONE;
+    expr->cmpnt.u->atom.list = list;
+    expr->cmpnt.u->type = EXPRATOM_EXPRLIST;
+    expr->cmpnt.u->op = UNARY_NONE;
     return expr;
 }
 
@@ -120,10 +120,10 @@ ms_Expr *ms_ExprFloatFromString(const char *str) {
         return NULL;
     }
 
-    expr->expr.u->expr.val.type = MSVAL_FLOAT;
-    expr->expr.u->expr.val.val.f = f;
-    expr->expr.u->type = EXPRATOM_VALUE;
-    expr->expr.u->op = UNARY_NONE;
+    expr->cmpnt.u->atom.val.type = MSVAL_FLOAT;
+    expr->cmpnt.u->atom.val.val.f = f;
+    expr->cmpnt.u->type = EXPRATOM_VALUE;
+    expr->cmpnt.u->op = UNARY_NONE;
     return expr;
 }
 
@@ -142,10 +142,10 @@ ms_Expr *ms_ExprIntFromString(const char *str) {
         return NULL;
     }
 
-    expr->expr.u->expr.val.type = MSVAL_INT;
-    expr->expr.u->expr.val.val.i = i;
-    expr->expr.u->type = EXPRATOM_VALUE;
-    expr->expr.u->op = UNARY_NONE;
+    expr->cmpnt.u->atom.val.type = MSVAL_INT;
+    expr->cmpnt.u->atom.val.val.i = i;
+    expr->cmpnt.u->type = EXPRATOM_VALUE;
+    expr->cmpnt.u->op = UNARY_NONE;
     return expr;
 }
 
@@ -153,37 +153,37 @@ ms_Expr *ms_ExprFlatten(ms_Expr *outer, ms_Expr *inner, ms_ExprLocation loc) {
     if ((!outer) || (!inner)) { return NULL; }
 
     bool should_flatten = (inner->type == EXPRTYPE_UNARY) &&
-                          (inner->expr.u->op == UNARY_NONE);
+                          (inner->cmpnt.u->op == UNARY_NONE);
 
     switch (loc) {
         case EXPRLOC_UNARY:
             assert(outer->type == EXPRTYPE_UNARY);
             if (!should_flatten) {
-                outer->expr.u->expr.expr = inner;
-                outer->expr.u->type = EXPRATOM_EXPRESSION;
+                outer->cmpnt.u->atom.expr = inner;
+                outer->cmpnt.u->type = EXPRATOM_EXPRESSION;
             } else {
-                outer->expr.u->expr = inner->expr.u->expr;
-                outer->expr.u->type = inner->expr.u->type;
+                outer->cmpnt.u->atom = inner->cmpnt.u->atom;
+                outer->cmpnt.u->type = inner->cmpnt.u->type;
             }
             break;
         case EXPRLOC_LEFT:
             assert(outer->type == EXPRTYPE_BINARY);
             if (!should_flatten) {
-                outer->expr.b->left.expr = inner;
-                outer->expr.b->ltype = EXPRATOM_EXPRESSION;
+                outer->cmpnt.b->latom.expr = inner;
+                outer->cmpnt.b->ltype = EXPRATOM_EXPRESSION;
             } else {
-                outer->expr.b->left = inner->expr.u->expr;
-                outer->expr.b->ltype = inner->expr.u->type;
+                outer->cmpnt.b->latom = inner->cmpnt.u->atom;
+                outer->cmpnt.b->ltype = inner->cmpnt.u->type;
             }
             break;
         case EXPRLOC_RIGHT:
             assert(outer->type == EXPRTYPE_BINARY);
             if (!should_flatten) {
-                outer->expr.b->right.expr = inner;
-                outer->expr.b->rtype = EXPRATOM_EXPRESSION;
+                outer->cmpnt.b->ratom.expr = inner;
+                outer->cmpnt.b->rtype = EXPRATOM_EXPRESSION;
             } else {
-                outer->expr.b->right = inner->expr.u->expr;
-                outer->expr.b->rtype = inner->expr.u->type;
+                outer->cmpnt.b->ratom = inner->cmpnt.u->atom;
+                outer->cmpnt.b->rtype = inner->cmpnt.u->type;
             }
             break;
     }
@@ -191,15 +191,15 @@ ms_Expr *ms_ExprFlatten(ms_Expr *outer, ms_Expr *inner, ms_ExprLocation loc) {
     /* clear pointers to objects such as lists and strings that would
      * be destroyed when the inner expression is destroyed otherwise */
     if (should_flatten) {
-        switch (inner->expr.u->type) {
+        switch (inner->cmpnt.u->type) {
             case EXPRATOM_EXPRESSION:
-                inner->expr.u->expr.expr = NULL;
+                inner->cmpnt.u->atom.expr = NULL;
                 break;
             case EXPRATOM_EXPRLIST:
-                inner->expr.u->expr.list = NULL;
+                inner->cmpnt.u->atom.list = NULL;
                 break;
             case EXPRATOM_IDENT:
-                inner->expr.u->expr.ident = NULL;
+                inner->cmpnt.u->atom.ident = NULL;
                 break;
             case EXPRATOM_VALUE:
             case EXPRATOM_EMPTY:
@@ -215,63 +215,63 @@ void ms_ExprDestroy(ms_Expr *expr) {
     if (!expr) { return; }
     switch (expr->type) {
         case EXPRTYPE_UNARY:
-            if (expr->expr.u) {
-                switch(expr->expr.u->type) {
+            if (expr->cmpnt.u) {
+                switch(expr->cmpnt.u->type) {
                     case EXPRATOM_EXPRESSION:
-                        ms_ExprDestroy(expr->expr.u->expr.expr);
+                        ms_ExprDestroy(expr->cmpnt.u->atom.expr);
                         break;
                     case EXPRATOM_IDENT:
-                        dsbuf_destroy(expr->expr.u->expr.ident);
-                        expr->expr.u->expr.ident = NULL;
+                        dsbuf_destroy(expr->cmpnt.u->atom.ident);
+                        expr->cmpnt.u->atom.ident = NULL;
                         break;
                     case EXPRATOM_EXPRLIST:
-                        dsarray_destroy(expr->expr.u->expr.list);
-                        expr->expr.u->expr.list = NULL;
+                        dsarray_destroy(expr->cmpnt.u->atom.list);
+                        expr->cmpnt.u->atom.list = NULL;
                         break;
                     case EXPRATOM_VALUE:    /* no free required */
                     case EXPRATOM_EMPTY:    /* no free required */
                         break;
                 }
-                free(expr->expr.u);
-                expr->expr.u = NULL;
+                free(expr->cmpnt.u);
+                expr->cmpnt.u = NULL;
             }
             break;
         case EXPRTYPE_BINARY:
-            if (expr->expr.b) {
-                switch (expr->expr.b->ltype) {
+            if (expr->cmpnt.b) {
+                switch (expr->cmpnt.b->ltype) {
                     case EXPRATOM_EXPRESSION:
-                        ms_ExprDestroy(expr->expr.b->left.expr);
+                        ms_ExprDestroy(expr->cmpnt.b->latom.expr);
                         break;
                     case EXPRATOM_IDENT:
-                        dsbuf_destroy(expr->expr.b->left.ident);
-                        expr->expr.b->left.ident = NULL;
+                        dsbuf_destroy(expr->cmpnt.b->latom.ident);
+                        expr->cmpnt.b->latom.ident = NULL;
                         break;
                     case EXPRATOM_EXPRLIST:
-                        dsarray_destroy(expr->expr.b->left.list);
-                        expr->expr.b->left.list = NULL;
+                        dsarray_destroy(expr->cmpnt.b->latom.list);
+                        expr->cmpnt.b->latom.list = NULL;
                         break;
                     case EXPRATOM_VALUE:    /* no free required */
                     case EXPRATOM_EMPTY:    /* no free required */
                         break;
                 }
-                switch(expr->expr.b->rtype) {
+                switch(expr->cmpnt.b->rtype) {
                     case EXPRATOM_EXPRESSION:
-                        ms_ExprDestroy(expr->expr.b->right.expr);
+                        ms_ExprDestroy(expr->cmpnt.b->ratom.expr);
                         break;
                     case EXPRATOM_IDENT:
-                        dsbuf_destroy(expr->expr.b->right.ident);
-                        expr->expr.b->right.ident = NULL;
+                        dsbuf_destroy(expr->cmpnt.b->ratom.ident);
+                        expr->cmpnt.b->ratom.ident = NULL;
                         break;
                     case EXPRATOM_EXPRLIST:
-                        dsarray_destroy(expr->expr.b->right.list);
-                        expr->expr.b->right.list = NULL;
+                        dsarray_destroy(expr->cmpnt.b->ratom.list);
+                        expr->cmpnt.b->ratom.list = NULL;
                         break;
                     case EXPRATOM_VALUE:    /* no free required */
                     case EXPRATOM_EMPTY:    /* no free required */
                         break;
                 }
-                free(expr->expr.b);
-                expr->expr.b = NULL;
+                free(expr->cmpnt.b);
+                expr->cmpnt.b = NULL;
             }
             break;
     }

--- a/src/lang.c
+++ b/src/lang.c
@@ -26,33 +26,6 @@ static const int EXPR_OPCODE_STACK_LEN = 50;
 static const int EXPR_VALUE_STACK_LEN = 50;
 static const int EXPR_IDENT_STACK_LEN = 50;
 
-// Static table of operator precedence values
-static const ms_ExprOpPrecedence OP_PRECEDENCE[] = {
-    { OP_UMINUS, 110, ASSOC_RIGHT },
-    { OP_NOT, 110, ASSOC_RIGHT },
-    { OP_BITWISE_NOT, 110, ASSOC_RIGHT },
-    { OP_TIMES, 100, ASSOC_LEFT },
-    { OP_DIVIDE, 100, ASSOC_LEFT },
-    { OP_IDIVIDE, 100, ASSOC_LEFT },
-    { OP_EXPONENTIATE, 100, ASSOC_LEFT },
-    { OP_MODULO, 100, ASSOC_LEFT },
-    { OP_PLUS, 90, ASSOC_LEFT },
-    { OP_MINUS, 90, ASSOC_LEFT },
-    { OP_SHIFT_LEFT, 80, ASSOC_LEFT },
-    { OP_SHIFT_RIGHT, 80, ASSOC_LEFT },
-    { OP_BITWISE_AND, 75, ASSOC_LEFT },
-    { OP_BITWISE_XOR, 70, ASSOC_LEFT },
-    { OP_BITWISE_OR, 65, ASSOC_LEFT },
-    { OP_LE, 60, ASSOC_LEFT },
-    { OP_LT, 60, ASSOC_LEFT },
-    { OP_GE, 60, ASSOC_LEFT },
-    { OP_GT, 60, ASSOC_LEFT },
-    { OP_EQ, 50, ASSOC_LEFT },
-    { OP_NOT_EQ, 50, ASSOC_LEFT },
-    { OP_AND, 40, ASSOC_LEFT },
-    { OP_OR, 30, ASSOC_LEFT }
-};
-
 static void ExprToOpCodes(ms_Expr *expr, DSArray *opcodes, DSArray *values, DSArray *idents);
 static void ExprComponentToOpCodes(ms_ExprAtom *a, ms_ExprAtomType type, DSArray *opcodes, DSArray *values, DSArray *idents);
 static void ExprOpToOpCode(ms_Expr *expr, DSArray *opcodes);
@@ -340,12 +313,6 @@ void ms_ExprDestroy(ms_Expr *expr) {
             break;
     }
     free(expr);
-}
-
-size_t ms_ExprOpPrecedenceTable(const ms_ExprOpPrecedence **tbl) {
-    size_t len = sizeof(OP_PRECEDENCE) / sizeof(OP_PRECEDENCE[0]);
-    *tbl = OP_PRECEDENCE;
-    return len;
 }
 
 ms_ExprBinaryOp ms_ExprTokenToBinaryOp(ms_TokenType type) {

--- a/src/lang.h
+++ b/src/lang.h
@@ -210,16 +210,6 @@ ms_VMByteCode *ms_ExprToOpCodes(ms_Expr *expr);
 void ms_ExprDestroy(ms_Expr *expr);
 
 /*
-* @brief Convert a token type into a binary operation enumeration.
-*/
-ms_ExprBinaryOp ms_ExprTokenToBinaryOp(ms_TokenType type);
-
-/**
-* @brief Convert a token type into a unary operation enumeration.
-*/
-ms_ExprUnaryOp ms_ExprTokenToUnaryOp(ms_TokenType type);
-
-/*
 * @brief Placeholder for real AST destroy function.
 */
 #define ms_ASTDestroy(ast) ms_ExprDestroy(ast)

--- a/src/lang.h
+++ b/src/lang.h
@@ -18,6 +18,7 @@
 #define MSCRIPT_LANG_H
 
 #include "libds/array.h"
+#include "libds/buffer.h"
 #include "lexer.h"
 #include "vm.h"
 
@@ -45,21 +46,9 @@ typedef struct ms_ExprOpPrecedence {
 typedef struct ms_Expr ms_Expr;
 
 /**
-* @brief Type of function
+* @brief Expression list object
 */
-typedef enum {
-    FUNCTYPE_BUILTIN,
-    FUNCTYPE_USER,
-} ms_FuncType;
-
-/**
-* @brief Function call object
-*/
-typedef struct ms_FuncCall {
-    DSBuffer *name;
-    ms_FuncType type;
-    DSArray *params;
-} ms_FuncCall;
+typedef DSArray ms_ExprList;
 
 /**
 * @brief Expression atom union
@@ -67,7 +56,8 @@ typedef struct ms_FuncCall {
 typedef union {
     ms_Expr *expr;
     ms_VMValue val;
-    ms_FuncCall fc;
+    ms_VMIdent *ident;
+    ms_ExprList *list;
 } ms_ExprAtom;
 
 /**
@@ -77,7 +67,8 @@ typedef enum {
     EXPRATOM_EMPTY,
     EXPRATOM_EXPRESSION,
     EXPRATOM_VALUE,
-    EXPRATOM_FUNCCALL,
+    EXPRATOM_IDENT,
+    EXPRATOM_EXPRLIST,
 } ms_ExprAtomType;
 
 /**
@@ -124,6 +115,7 @@ typedef enum {
     BINARY_NOT_EQ,
     BINARY_AND,
     BINARY_OR,
+    BINARY_CALL,
 } ms_ExprBinaryOp;
 
 /**
@@ -187,9 +179,14 @@ ms_Expr *ms_ExprNew(ms_ExprType type);
 ms_Expr *ms_ExprNewWithVal(ms_VMDataType type, ms_VMData v);
 
 /**
-* @brief Create a new @c ms_Expr object for a function call.
+* @brief Create a new @c ms_Expr object for an identifier.
 */
-ms_Expr *ms_ExprNewWithFuncCall(const char *name, ms_FuncType type);
+ms_Expr *ms_ExprNewWithIdent(const char *name);
+
+/**
+* @brief Create a new @c ms_Expr object for containing a list of expressions.
+*/
+ms_Expr *ms_ExprNewWithList(ms_ExprList *list);
 
 /**
 * @brief Create a new unary @c ms_Expr object containing a floating point

--- a/src/lang.h
+++ b/src/lang.h
@@ -20,7 +20,6 @@
 #include "libds/array.h"
 #include "libds/buffer.h"
 #include "lexer.h"
-#include "vm.h"
 
 /**
 * @brief Expression syntax tree object
@@ -28,17 +27,61 @@
 typedef struct ms_Expr ms_Expr;
 
 /**
+* @brief Identifier
+*/
+typedef DSBuffer ms_Ident;
+
+/**
 * @brief Expression list object
 */
 typedef DSArray ms_ExprList;
+
+/*
+* @brief Typedefs of mscript values
+*/
+typedef double ms_ValFloat;
+typedef long long ms_ValInt;
+typedef DSBuffer ms_ValStr;
+typedef bool ms_ValBool;
+typedef const void ms_ValNull;
+
+/**
+* @brief Enumeration of data value types in mscript
+*/
+typedef enum {
+    MSVAL_FLOAT,
+    MSVAL_INT,
+    MSVAL_STR,
+    MSVAL_BOOL,
+    MSVAL_NULL,
+} ms_ValDataType;
+
+/**
+* @brief Union of data types in mscript
+*/
+typedef union {
+    ms_ValFloat f;
+    ms_ValInt i;
+    ms_ValStr *s;
+    ms_ValBool b;
+    ms_ValNull *n;
+} ms_ValData;
+
+/**
+* @brief Structure of any value within mscript
+*/
+typedef struct {
+    ms_ValDataType type;
+    ms_ValData val;
+} ms_Value;
 
 /**
 * @brief Expression atom union
 */
 typedef union {
     ms_Expr *expr;
-    ms_VMValue val;
-    ms_VMIdent *ident;
+    ms_Value val;
+    ms_Ident *ident;
     ms_ExprList *list;
 } ms_ExprAtom;
 
@@ -158,12 +201,12 @@ ms_Expr *ms_ExprNew(ms_ExprType type);
 /**
 * @brief Create a new @c ms_Expr object with a primitive value.
 */
-ms_Expr *ms_ExprNewWithVal(ms_VMDataType type, ms_VMData v);
+ms_Expr *ms_ExprNewWithVal(ms_ValDataType type, ms_ValData v);
 
 /**
 * @brief Create a new @c ms_Expr object for an identifier.
 */
-ms_Expr *ms_ExprNewWithIdent(const char *name);
+ms_Expr *ms_ExprNewWithIdent(const char *name, size_t len);
 
 /**
 * @brief Create a new @c ms_Expr object for containing a list of expressions.
@@ -198,11 +241,6 @@ ms_Expr *ms_ExprIntFromString(const char *str);
 * @returns the outer expression
 */
 ms_Expr *ms_ExprFlatten(ms_Expr *outer, ms_Expr *inner, ms_ExprLocation loc);
-
-/**
-* @brief Generate mscript VM bytecode from the given expression value.
-*/
-ms_VMByteCode *ms_ExprToOpCodes(ms_Expr *expr);
 
 /**
 * @brief Destroy the given @c ms_Expr and any nested expressions.

--- a/src/lang.h
+++ b/src/lang.h
@@ -45,11 +45,29 @@ typedef struct ms_ExprOpPrecedence {
 typedef struct ms_Expr ms_Expr;
 
 /**
+* @brief Type of function
+*/
+typedef enum {
+    FUNCTYPE_BUILTIN,
+    FUNCTYPE_USER,
+} ms_FuncType;
+
+/**
+* @brief Function call object
+*/
+typedef struct ms_FuncCall {
+    DSBuffer *name;
+    ms_FuncType type;
+    DSArray *params;
+} ms_FuncCall;
+
+/**
 * @brief Expression atom union
 */
 typedef union {
     ms_Expr *expr;
     ms_VMValue val;
+    ms_FuncCall fc;
 } ms_ExprAtom;
 
 /**
@@ -59,6 +77,7 @@ typedef enum {
     EXPRATOM_EMPTY,
     EXPRATOM_EXPRESSION,
     EXPRATOM_VALUE,
+    EXPRATOM_FUNCCALL,
 } ms_ExprAtomType;
 
 /**
@@ -166,6 +185,11 @@ ms_Expr *ms_ExprNew(ms_ExprType type);
 * @brief Create a new @c ms_Expr object with a primitive value.
 */
 ms_Expr *ms_ExprNewWithVal(ms_VMDataType type, ms_VMData v);
+
+/**
+* @brief Create a new @c ms_Expr object for a function call.
+*/
+ms_Expr *ms_ExprNewWithFuncCall(const char *name, ms_FuncType type);
 
 /**
 * @brief Create a new unary @c ms_Expr object containing a floating point

--- a/src/lang.h
+++ b/src/lang.h
@@ -23,24 +23,6 @@
 #include "vm.h"
 
 /**
-* @brief Operator associativity enumeration
-*/
-typedef enum ms_ExprOpAssociativity {
-    ASSOC_LEFT,
-    ASSOC_RIGHT
-} ms_ExprOpAssociativity;
-
-/**
-* @brief Tuple structure representing the type and associativity of
-* mscript operators
-*/
-typedef struct ms_ExprOpPrecedence {
-    ms_TokenType type;
-    int precedence;
-    ms_ExprOpAssociativity assoc;
-} ms_ExprOpPrecedence;
-
-/**
 * @brief Expression syntax tree object
 */
 typedef struct ms_Expr ms_Expr;
@@ -226,11 +208,6 @@ ms_VMByteCode *ms_ExprToOpCodes(ms_Expr *expr);
 * @brief Destroy the given @c ms_Expr and any nested expressions.
 */
 void ms_ExprDestroy(ms_Expr *expr);
-
-/**
-* @brief Fill a pointer to the operator precedence table for callers.
-*/
-size_t ms_ExprOpPrecedenceTable(const ms_ExprOpPrecedence **tbl);
 
 /*
 * @brief Convert a token type into a binary operation enumeration.

--- a/src/lang.h
+++ b/src/lang.h
@@ -110,7 +110,7 @@ typedef enum {
 * @brief Unary expression object
 */
 typedef struct {
-    ms_ExprAtom expr;
+    ms_ExprAtom atom;
     ms_ExprAtomType type;
     ms_ExprUnaryOp op;
 } ms_ExprUnary;
@@ -147,10 +147,10 @@ typedef enum {
 * @brief Binary expression object
 */
 typedef struct {
-    ms_ExprAtom left;
+    ms_ExprAtom latom;
     ms_ExprAtomType ltype;
     ms_ExprBinaryOp op;
-    ms_ExprAtom right;
+    ms_ExprAtom ratom;
     ms_ExprAtomType rtype;
 } ms_ExprBinary;
 
@@ -174,7 +174,7 @@ typedef enum {
 * @brief Expression object
 */
 struct ms_Expr {
-    ms_ExprComponent expr;
+    ms_ExprComponent cmpnt;
     ms_ExprType type;
 };
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -425,11 +425,6 @@ char *ms_TokenToString(ms_Token *tok) {
     return str;
 }
 
-bool ms_TokenIsOp(ms_Token *tok) {
-    assert(tok);
-    return ms_TokenTypeIsOp(tok->type);
-}
-
 void ms_TokenDestroy(ms_Token *tok) {
     if (!tok) { return; }
     dsbuf_destroy(tok->value);
@@ -520,38 +515,6 @@ const char *ms_TokenTypeName(ms_TokenType type) {
 
     assert(false);
     return NULL;
-}
-
-bool ms_TokenTypeIsOp(ms_TokenType type) {
-    switch(type) {
-        case OP_UMINUS:
-        case OP_PLUS:
-        case OP_MINUS:
-        case OP_TIMES:
-        case OP_DIVIDE:
-        case OP_IDIVIDE:
-        case OP_MODULO:
-        case OP_AND:
-        case OP_OR:
-        case OP_EXPONENTIATE:
-        case OP_DOUBLE_EQ:
-        case OP_GT:
-        case OP_LT:
-        case OP_EQ:
-        case OP_NOT:
-        case OP_NOT_EQ:
-        case OP_GE:
-        case OP_LE:
-        case OP_BITWISE_AND:
-        case OP_BITWISE_OR:
-        case OP_BITWISE_XOR:
-        case OP_BITWISE_NOT:
-        case OP_SHIFT_LEFT:
-        case OP_SHIFT_RIGHT:
-            return true;
-        default:
-            return false;
-    }
 }
 
 /*

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -180,13 +180,13 @@ begin_lex:              // Jump label for ignored input
             if (!LexerAcceptOne(lex, "\n")) {
                 return LexerTokenError(lex, "\\r");
             }
-            return LexerTokenFromBuffer(lex, NEWLINE);
+            return LexerTokenFromBuffer(lex, NEWLINE_TOK);
 
             // Newlines \n
         case '\n':
             LexerIncrementLine(lex);
             LexerAddToBuffer(lex, n);
-            return LexerTokenFromBuffer(lex, NEWLINE);
+            return LexerTokenFromBuffer(lex, NEWLINE_TOK);
 
             // Spaces and tabs
         case ' ':
@@ -510,7 +510,7 @@ const char *ms_TokenTypeName(ms_TokenType type) {
         case RBRACE:            return TOK_RBRACE;
         case PERIOD:            return TOK_PERIOD;
         case COMMA:             return TOK_COMMA;
-        case NEWLINE:           return TOK_NEWLINE;
+        case NEWLINE_TOK:       return TOK_NEWLINE;
     }
 
     assert(false);

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -278,14 +278,6 @@ ms_Token *ms_TokenNew(ms_TokenType type, const char *value, size_t len, size_t l
 char *ms_TokenToString(ms_Token *tok);
 
 /**
-* @brief Indicate if the given token qualifies as an operator.
-*
-* @param tok a token object
-* @returns true if the given token is an operator; false otherwise
-*/
-bool ms_TokenIsOp(ms_Token *tok);
-
-/**
 * @brief Destroy a token.
 *
 * @param tok a token object
@@ -307,13 +299,5 @@ const char *ms_TokenName(ms_Token *tok);
 * @returns the string name of the given token type
 */
 const char *ms_TokenTypeName(ms_TokenType type);
-
-/**
-* @brief Indicate if the given type of token qualifies as an operator.
-*
-* @param type a type of token
-* @returns true if the given token type is an operator; false otherwise
-*/
-bool ms_TokenTypeIsOp(ms_TokenType type);
 
 #endif //MSCRIPT_LEXER_H

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -169,7 +169,7 @@ typedef enum ms_TokenType {
     RBRACE,
     PERIOD,
     COMMA,
-    NEWLINE
+    NEWLINE_TOK
 } ms_TokenType;
 
 /**

--- a/src/obj.c
+++ b/src/obj.c
@@ -20,7 +20,7 @@
 #include "vm.h"
 
 /*
- * FLOAT PROTOTYPE FUNCTIONS
+ * PROTOTYPE FUNCTIONS
  */
 
 static int ms_FloatToStr(ms_VM *vm);
@@ -266,34 +266,34 @@ static int ms_FloatToFloat(ms_VM *vm) {
 
 static int ms_FloatToInt(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
-    ms_VMPushInt(vm, (ms_VMInt)l.val.f);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
+    ms_VMPushInt(vm, (ms_ValInt)l.val.f);
     return 1;
 }
 
 static int ms_FloatToBool(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
-    ms_VMPushBool(vm, (ms_VMBool)(l.val.f != 0.0));
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
+    ms_VMPushBool(vm, (ms_ValBool)(l.val.f != 0.0));
     return 1;
 }
 
 static int ms_FloatAdd(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushFloat(vm, l.val.f + (ms_VMFloat)r.val.i);
+        case MSVAL_INT:
+            ms_VMPushFloat(vm, l.val.f + (ms_ValFloat)r.val.i);
             return 1;
-        case VMVAL_FLOAT:
+        case MSVAL_FLOAT:
             ms_VMPushFloat(vm, l.val.f + r.val.f);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushFloat(vm, l.val.f + (ms_VMFloat)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushFloat(vm, l.val.f + (ms_ValFloat)r.val.b);
             return 1;
         default:
             return 0;
@@ -302,18 +302,18 @@ static int ms_FloatAdd(ms_VM *vm) {
 
 static int ms_FloatSubtract(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushFloat(vm, l.val.f - (ms_VMFloat)r.val.i);
+        case MSVAL_INT:
+            ms_VMPushFloat(vm, l.val.f - (ms_ValFloat)r.val.i);
             return 1;
-        case VMVAL_FLOAT:
+        case MSVAL_FLOAT:
             ms_VMPushFloat(vm, l.val.f - r.val.f);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushFloat(vm, l.val.f - (ms_VMFloat)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushFloat(vm, l.val.f - (ms_ValFloat)r.val.b);
             return 1;
         default:
             return 0;
@@ -322,18 +322,18 @@ static int ms_FloatSubtract(ms_VM *vm) {
 
 static int ms_FloatMultiply(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushFloat(vm, l.val.f * (ms_VMFloat)r.val.i);
+        case MSVAL_INT:
+            ms_VMPushFloat(vm, l.val.f * (ms_ValFloat)r.val.i);
             return 1;
-        case VMVAL_FLOAT:
+        case MSVAL_FLOAT:
             ms_VMPushFloat(vm, l.val.f * r.val.f);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushFloat(vm, l.val.f * (ms_VMFloat)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushFloat(vm, l.val.f * (ms_ValFloat)r.val.b);
             return 1;
         default:
             return 0;
@@ -342,21 +342,21 @@ static int ms_FloatMultiply(ms_VM *vm) {
 
 static int ms_FloatDivide(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             if (r.val.i == 0) { return 0; }
-            ms_VMPushFloat(vm, l.val.f / (ms_VMFloat)r.val.i);
+            ms_VMPushFloat(vm, l.val.f / (ms_ValFloat)r.val.i);
             return 1;
-        case VMVAL_FLOAT:
+        case MSVAL_FLOAT:
             if (r.val.f == 0.0) { return 0; }
             ms_VMPushFloat(vm, l.val.f / r.val.f);
             return 1;
-        case VMVAL_BOOL:
+        case MSVAL_BOOL:
             if (r.val.b == false) { return 0; }
-            ms_VMPushFloat(vm, l.val.f / (ms_VMFloat)r.val.b);
+            ms_VMPushFloat(vm, l.val.f / (ms_ValFloat)r.val.b);
             return 1;
         default:
             return 0;
@@ -365,21 +365,21 @@ static int ms_FloatDivide(ms_VM *vm) {
 
 static int ms_FloatIDivide(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             if (r.val.i == 0) { return 0; }
-            ms_VMPushInt(vm, (ms_VMInt)l.val.f / r.val.i);
+            ms_VMPushInt(vm, (ms_ValInt)l.val.f / r.val.i);
             return 1;
-        case VMVAL_FLOAT:
+        case MSVAL_FLOAT:
             if (r.val.f == 0.0) { return 0; }
-            ms_VMPushInt(vm, (ms_VMInt)trunc(l.val.f) / (ms_VMInt)trunc(r.val.f));
+            ms_VMPushInt(vm, (ms_ValInt)trunc(l.val.f) / (ms_ValInt)trunc(r.val.f));
             return 1;
-        case VMVAL_BOOL:
+        case MSVAL_BOOL:
             if (r.val.b == false) { return 0; }
-            ms_VMPushInt(vm, (ms_VMInt)l.val.f / (ms_VMInt)r.val.b);
+            ms_VMPushInt(vm, (ms_ValInt)l.val.f / (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -388,18 +388,18 @@ static int ms_FloatIDivide(ms_VM *vm) {
 
 static int ms_FloatModulo(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushFloat(vm, (ms_VMFloat)fmod(l.val.f, (ms_VMFloat)r.val.i));
+        case MSVAL_INT:
+            ms_VMPushFloat(vm, (ms_ValFloat)fmod(l.val.f, (ms_ValFloat)r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushFloat(vm, (ms_VMFloat)fmod(l.val.f, r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushFloat(vm, (ms_ValFloat)fmod(l.val.f, r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushFloat(vm, (ms_VMFloat)fmod(l.val.f, (ms_VMFloat)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushFloat(vm, (ms_ValFloat)fmod(l.val.f, (ms_ValFloat)r.val.b));
             return 1;
         default:
             return 0;
@@ -408,18 +408,18 @@ static int ms_FloatModulo(ms_VM *vm) {
 
 static int ms_FloatExponentiate(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushFloat(vm, (ms_VMFloat)pow(l.val.f, (ms_VMFloat)r.val.i));
+        case MSVAL_INT:
+            ms_VMPushFloat(vm, (ms_ValFloat)pow(l.val.f, (ms_ValFloat)r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushFloat(vm, (ms_VMFloat)pow(l.val.f, r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushFloat(vm, (ms_ValFloat)pow(l.val.f, r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushFloat(vm, (ms_VMFloat)pow(l.val.f, (ms_VMFloat)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushFloat(vm, (ms_ValFloat)pow(l.val.f, (ms_ValFloat)r.val.b));
             return 1;
         default:
             return 0;
@@ -428,26 +428,26 @@ static int ms_FloatExponentiate(ms_VM *vm) {
 
 static int ms_FloatNegate(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     ms_VMPushFloat(vm, -l.val.f);
     return 1;
 }
 
 static int ms_FloatLessThan(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f < (ms_VMFloat)r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f < (ms_ValFloat)r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f < r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f < r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f < (ms_VMFloat)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f < (ms_ValFloat)r.val.b));
             return 1;
         default:
             return 0;
@@ -456,18 +456,18 @@ static int ms_FloatLessThan(ms_VM *vm) {
 
 static int ms_FloatLessEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f <= (ms_VMFloat)r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f <= (ms_ValFloat)r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f <= r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f <= r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f <= (ms_VMFloat)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f <= (ms_ValFloat)r.val.b));
             return 1;
         default:
             return 0;
@@ -476,18 +476,18 @@ static int ms_FloatLessEqual(ms_VM *vm) {
 
 static int ms_FloatGreaterThan(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f > (ms_VMFloat)r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f > (ms_ValFloat)r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f > r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f > r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f > (ms_VMFloat)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f > (ms_ValFloat)r.val.b));
             return 1;
         default:
             return 0;
@@ -496,18 +496,18 @@ static int ms_FloatGreaterThan(ms_VM *vm) {
 
 static int ms_FloatGreaterEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f >= (ms_VMFloat)r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f >= (ms_ValFloat)r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f >= r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f >= r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f >= (ms_VMFloat)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f >= (ms_ValFloat)r.val.b));
             return 1;
         default:
             return 0;
@@ -516,18 +516,18 @@ static int ms_FloatGreaterEqual(ms_VM *vm) {
 
 static int ms_FloatEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f == (ms_VMFloat)r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f == (ms_ValFloat)r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f == r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f == r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f == (ms_VMFloat)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f == (ms_ValFloat)r.val.b));
             return 1;
         default:
             return 0;
@@ -536,18 +536,18 @@ static int ms_FloatEqual(ms_VM *vm) {
 
 static int ms_FloatNotEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f != (ms_VMFloat)r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f != (ms_ValFloat)r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f != r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f != r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.f != (ms_VMFloat)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.f != (ms_ValFloat)r.val.b));
             return 1;
         default:
             return 0;
@@ -556,23 +556,23 @@ static int ms_FloatNotEqual(ms_VM *vm) {
 
 static int ms_FloatNot(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
-    ms_VMPushBool(vm, !(ms_VMBool)l.val.f);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
+    ms_VMPushBool(vm, !(ms_ValBool)l.val.f);
     return 1;
 }
 
 static int ms_FloatAnd(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
 
     ms_VMPush(vm, r);
     ms_Function tobool = ms_VMPrototypeFuncGet(vm, r.type, "__bool__");
     if ((tobool) && (tobool(vm) == 1)) {
         r = ms_VMPop(vm);
-        ms_VMPushBool(vm, (ms_VMBool)l.val.f && r.val.b);
+        ms_VMPushBool(vm, (ms_ValBool)l.val.f && r.val.b);
         return 1;
     }
 
@@ -582,10 +582,10 @@ static int ms_FloatAnd(ms_VM *vm) {
 
 static int ms_FloatOr(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_FLOAT);
-    if ((ms_VMBool)l.val.f) {
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_FLOAT);
+    if ((ms_ValBool)l.val.f) {
         ms_VMPushBool(vm, true);
         return 1;
     }
@@ -612,9 +612,9 @@ static int ms_IntToStr(ms_VM *vm) {
 
 static int ms_IntToFloat(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
-    ms_VMPushFloat(vm, (ms_VMFloat)l.val.i);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
+    ms_VMPushFloat(vm, (ms_ValFloat)l.val.i);
     return 1;
 }
 
@@ -624,26 +624,26 @@ static int ms_IntToInt(ms_VM *vm) {
 
 static int ms_IntToBool(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
-    ms_VMPushBool(vm, (ms_VMBool)(l.val.i != 0));
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
+    ms_VMPushBool(vm, (ms_ValBool)(l.val.i != 0));
     return 1;
 }
 
 static int ms_IntAdd(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             ms_VMPushInt(vm, l.val.i + r.val.i);
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushFloat(vm, (ms_VMFloat)l.val.i + r.val.f);
+        case MSVAL_FLOAT:
+            ms_VMPushFloat(vm, (ms_ValFloat)l.val.i + r.val.f);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, l.val.i + (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, l.val.i + (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -652,18 +652,18 @@ static int ms_IntAdd(ms_VM *vm) {
 
 static int ms_IntSubtract(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             ms_VMPushInt(vm, l.val.i - r.val.i);
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushFloat(vm, (ms_VMFloat)l.val.i - r.val.f);
+        case MSVAL_FLOAT:
+            ms_VMPushFloat(vm, (ms_ValFloat)l.val.i - r.val.f);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, l.val.i - (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, l.val.i - (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -672,18 +672,18 @@ static int ms_IntSubtract(ms_VM *vm) {
 
 static int ms_IntMultiply(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             ms_VMPushInt(vm, l.val.i * r.val.i);
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushFloat(vm, (ms_VMFloat)l.val.i * r.val.f);
+        case MSVAL_FLOAT:
+            ms_VMPushFloat(vm, (ms_ValFloat)l.val.i * r.val.f);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, l.val.i * (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, l.val.i * (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -692,21 +692,21 @@ static int ms_IntMultiply(ms_VM *vm) {
 
 static int ms_IntDivide(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             if (r.val.i == 0) { return 0; }
             ms_VMPushInt(vm, l.val.i / r.val.i);
             return 1;
-        case VMVAL_FLOAT:
+        case MSVAL_FLOAT:
             if (r.val.f == 0.0) { return 0; }
-            ms_VMPushFloat(vm, (ms_VMFloat)l.val.i / r.val.f);
+            ms_VMPushFloat(vm, (ms_ValFloat)l.val.i / r.val.f);
             return 1;
-        case VMVAL_BOOL:
+        case MSVAL_BOOL:
             if (r.val.b == false) { return 0; }
-            ms_VMPushInt(vm, l.val.i / (ms_VMInt)r.val.b);
+            ms_VMPushInt(vm, l.val.i / (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -715,21 +715,21 @@ static int ms_IntDivide(ms_VM *vm) {
 
 static int ms_IntIDivide(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             if (r.val.i == 0) { return 0; }
             ms_VMPushInt(vm, l.val.i / r.val.i);
             return 1;
-        case VMVAL_FLOAT:
+        case MSVAL_FLOAT:
             if (r.val.f == 0.0) { return 0; }
-            ms_VMPushFloat(vm, l.val.i / (ms_VMInt)r.val.f);
+            ms_VMPushFloat(vm, l.val.i / (ms_ValInt)r.val.f);
             return 1;
-        case VMVAL_BOOL:
+        case MSVAL_BOOL:
             if (r.val.b == false) { return 0; }
-            ms_VMPushInt(vm, l.val.i / (ms_VMInt)r.val.b);
+            ms_VMPushInt(vm, l.val.i / (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -738,21 +738,21 @@ static int ms_IntIDivide(ms_VM *vm) {
 
 static int ms_IntModulo(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             if (l.val.i == 0) { return 0; }
             ms_VMPushInt(vm, l.val.i % r.val.i);
             return 1;
-        case VMVAL_FLOAT:
+        case MSVAL_FLOAT:
             if (l.val.f == 0.0) { return 0; }
-            ms_VMPushFloat(vm, (ms_VMFloat)fmod((ms_VMFloat)l.val.i, r.val.f));
+            ms_VMPushFloat(vm, (ms_ValFloat)fmod((ms_ValFloat)l.val.i, r.val.f));
             return 1;
-        case VMVAL_BOOL:
+        case MSVAL_BOOL:
             if (l.val.b == false) { return 0; }
-            ms_VMPushInt(vm, l.val.i % (ms_VMInt)r.val.b);
+            ms_VMPushInt(vm, l.val.i % (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -761,18 +761,18 @@ static int ms_IntModulo(ms_VM *vm) {
 
 static int ms_IntExponentiate(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushInt(vm, (ms_VMInt)pow((ms_VMFloat)l.val.i, (ms_VMFloat)r.val.i));
+        case MSVAL_INT:
+            ms_VMPushInt(vm, (ms_ValInt)pow((ms_ValFloat)l.val.i, (ms_ValFloat)r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushFloat(vm, (ms_VMFloat)pow((ms_VMFloat)l.val.i, r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushFloat(vm, (ms_ValFloat)pow((ms_ValFloat)l.val.i, r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, (ms_VMInt)pow((ms_VMFloat)l.val.i, (ms_VMFloat)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, (ms_ValInt)pow((ms_ValFloat)l.val.i, (ms_ValFloat)r.val.b));
             return 1;
         default:
             return 0;
@@ -781,23 +781,23 @@ static int ms_IntExponentiate(ms_VM *vm) {
 
 static int ms_IntNegate(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     ms_VMPushInt(vm, -l.val.i);
     return 1;
 }
 
 static int ms_IntLShift(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             ms_VMPushInt(vm, l.val.i << r.val.i);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, l.val.i << (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, l.val.i << (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -806,15 +806,15 @@ static int ms_IntLShift(ms_VM *vm) {
 
 static int ms_IntRShift(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             ms_VMPushInt(vm, l.val.i >> r.val.i);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, l.val.i >> (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, l.val.i >> (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -823,15 +823,15 @@ static int ms_IntRShift(ms_VM *vm) {
 
 static int ms_IntBitwiseAnd(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             ms_VMPushInt(vm, l.val.i & r.val.i);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, l.val.i & (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, l.val.i & (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -840,15 +840,15 @@ static int ms_IntBitwiseAnd(ms_VM *vm) {
 
 static int ms_IntBitwiseXor(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             ms_VMPushInt(vm, l.val.i ^ r.val.i);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, l.val.i ^ (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, l.val.i ^ (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -857,15 +857,15 @@ static int ms_IntBitwiseXor(ms_VM *vm) {
 
 static int ms_IntBitwiseOr(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             ms_VMPushInt(vm, l.val.i | r.val.i);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, l.val.i | (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, l.val.i | (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -874,26 +874,26 @@ static int ms_IntBitwiseOr(ms_VM *vm) {
 
 static int ms_IntBitwiseNot(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     ms_VMPushInt(vm, ~l.val.i);
     return 1;
 }
 
 static int ms_IntLessThan(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.i < r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.i < r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMFloat)l.val.i < r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValFloat)l.val.i < r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, (ms_VMBool)(l.val.i < (ms_VMInt)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, (ms_ValBool)(l.val.i < (ms_ValInt)r.val.b));
             return 1;
         default:
             return 0;
@@ -902,18 +902,18 @@ static int ms_IntLessThan(ms_VM *vm) {
 
 static int ms_IntLessEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.i <= r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.i <= r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMFloat)l.val.i <= r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValFloat)l.val.i <= r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.i <= (ms_VMInt)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.i <= (ms_ValInt)r.val.b));
             return 1;
         default:
             return 0;
@@ -922,18 +922,18 @@ static int ms_IntLessEqual(ms_VM *vm) {
 
 static int ms_IntGreaterThan(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.i > r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.i > r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMFloat)l.val.i > r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValFloat)l.val.i > r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.i > (ms_VMInt)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.i > (ms_ValInt)r.val.b));
             return 1;
         default:
             return 0;
@@ -942,18 +942,18 @@ static int ms_IntGreaterThan(ms_VM *vm) {
 
 static int ms_IntGreaterEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.i >= r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.i >= r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMFloat)l.val.i >= r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValFloat)l.val.i >= r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.i >= (ms_VMInt)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.i >= (ms_ValInt)r.val.b));
             return 1;
         default:
             return 0;
@@ -962,18 +962,18 @@ static int ms_IntGreaterEqual(ms_VM *vm) {
 
 static int ms_IntEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.i == r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.i == r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMFloat)l.val.i == r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValFloat)l.val.i == r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.i == (ms_VMInt)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.i == (ms_ValInt)r.val.b));
             return 1;
         default:
             return 0;
@@ -982,18 +982,18 @@ static int ms_IntEqual(ms_VM *vm) {
 
 static int ms_IntNotEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.i != r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.i != r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMFloat)l.val.i != r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValFloat)l.val.i != r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)(l.val.i != (ms_VMInt)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)(l.val.i != (ms_ValInt)r.val.b));
             return 1;
         default:
             return 0;
@@ -1002,23 +1002,23 @@ static int ms_IntNotEqual(ms_VM *vm) {
 
 static int ms_IntNot(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
-    ms_VMPushBool(vm, !(ms_VMBool)l.val.i);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
+    ms_VMPushBool(vm, !(ms_ValBool)l.val.i);
     return 1;
 }
 
 static int ms_IntAnd(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
 
     ms_VMPush(vm, r);
     ms_Function tobool = ms_VMPrototypeFuncGet(vm, r.type, "__bool__");
     if ((tobool) && (tobool(vm) == 1)) {
         r = ms_VMPop(vm);
-        ms_VMPushBool(vm, (ms_VMBool)l.val.i && r.val.b);
+        ms_VMPushBool(vm, (ms_ValBool)l.val.i && r.val.b);
         return 1;
     }
 
@@ -1028,10 +1028,10 @@ static int ms_IntAnd(ms_VM *vm) {
 
 static int ms_IntOr(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_INT);
-    if ((ms_VMBool)l.val.i) {
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_INT);
+    if ((ms_ValBool)l.val.i) {
         ms_VMPushBool(vm, true);
         return 1;
     }
@@ -1118,17 +1118,17 @@ static int ms_BoolToStr(ms_VM *vm) {
 
 static int ms_BoolToFloat(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
-    ms_VMPushFloat(vm, (ms_VMFloat)l.val.b);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
+    ms_VMPushFloat(vm, (ms_ValFloat)l.val.b);
     return 1;
 }
 
 static int ms_BoolToInt(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
-    ms_VMPushInt(vm, (ms_VMInt)l.val.b);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
+    ms_VMPushInt(vm, (ms_ValInt)l.val.b);
     return 1;
 }
 
@@ -1138,18 +1138,18 @@ static int ms_BoolToBool(ms_VM *vm) {
 
 static int ms_BoolAdd(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b + r.val.i);
+        case MSVAL_INT:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b + r.val.i);
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushFloat(vm, (ms_VMFloat)l.val.b + r.val.f);
+        case MSVAL_FLOAT:
+            ms_VMPushFloat(vm, (ms_ValFloat)l.val.b + r.val.f);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b + (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b + (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -1158,18 +1158,18 @@ static int ms_BoolAdd(ms_VM *vm) {
 
 static int ms_BoolSubtract(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b - r.val.i);
+        case MSVAL_INT:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b - r.val.i);
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushFloat(vm, (ms_VMFloat)l.val.b - r.val.f);
+        case MSVAL_FLOAT:
+            ms_VMPushFloat(vm, (ms_ValFloat)l.val.b - r.val.f);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b - (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b - (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -1178,18 +1178,18 @@ static int ms_BoolSubtract(ms_VM *vm) {
 
 static int ms_BoolMultiply(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b * r.val.i);
+        case MSVAL_INT:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b * r.val.i);
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushFloat(vm, (ms_VMFloat)l.val.b * r.val.f);
+        case MSVAL_FLOAT:
+            ms_VMPushFloat(vm, (ms_ValFloat)l.val.b * r.val.f);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b * (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b * (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -1198,21 +1198,21 @@ static int ms_BoolMultiply(ms_VM *vm) {
 
 static int ms_BoolDivide(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             if (r.val.i == 0) { return 0; }
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b / r.val.i);
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b / r.val.i);
             return 1;
-        case VMVAL_FLOAT:
+        case MSVAL_FLOAT:
             if (r.val.f == 0.0) { return 0; }
-            ms_VMPushFloat(vm, (ms_VMFloat)l.val.b / r.val.f);
+            ms_VMPushFloat(vm, (ms_ValFloat)l.val.b / r.val.f);
             return 1;
-        case VMVAL_BOOL:
+        case MSVAL_BOOL:
             if (r.val.b == false) { return 0; }
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b / (ms_VMInt)r.val.b);
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b / (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -1221,21 +1221,21 @@ static int ms_BoolDivide(ms_VM *vm) {
 
 static int ms_BoolIDivide(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
+        case MSVAL_INT:
             if (r.val.i == 0) { return 0; }
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b / r.val.i);
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b / r.val.i);
             return 1;
-        case VMVAL_FLOAT:
+        case MSVAL_FLOAT:
             if (r.val.f == 0.0) { return 0; }
-            ms_VMPushFloat(vm, (ms_VMInt)(l.val.b / (ms_VMInt)r.val.f));
+            ms_VMPushFloat(vm, (ms_ValInt)(l.val.b / (ms_ValInt)r.val.f));
             return 1;
-        case VMVAL_BOOL:
+        case MSVAL_BOOL:
             if (r.val.b == false) { return 0; }
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b / (ms_VMInt)r.val.b);
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b / (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -1248,18 +1248,18 @@ static int ms_BoolModulo(ms_VM *vm) {
 
 static int ms_BoolExponentiate(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushInt(vm, (ms_VMInt)pow((ms_VMFloat)l.val.b, (ms_VMFloat)r.val.i));
+        case MSVAL_INT:
+            ms_VMPushInt(vm, (ms_ValInt)pow((ms_ValFloat)l.val.b, (ms_ValFloat)r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushInt(vm, (ms_VMInt)pow((ms_VMFloat)l.val.b, r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushInt(vm, (ms_ValInt)pow((ms_ValFloat)l.val.b, r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, (ms_VMInt)pow((ms_VMFloat)l.val.b, (ms_VMFloat)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, (ms_ValInt)pow((ms_ValFloat)l.val.b, (ms_ValFloat)r.val.b));
             return 1;
         default:
             return 0;
@@ -1268,23 +1268,23 @@ static int ms_BoolExponentiate(ms_VM *vm) {
 
 static int ms_BoolNegate(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
-    ms_VMPushInt(vm, -((ms_VMInt)l.val.b));
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
+    ms_VMPushInt(vm, -((ms_ValInt)l.val.b));
     return 1;
 }
 
 static int ms_BoolLShift(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b << r.val.i);
+        case MSVAL_INT:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b << r.val.i);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b << (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b << (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -1293,15 +1293,15 @@ static int ms_BoolLShift(ms_VM *vm) {
 
 static int ms_BoolRShift(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b >> r.val.i);
+        case MSVAL_INT:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b >> r.val.i);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b >> (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b >> (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -1310,15 +1310,15 @@ static int ms_BoolRShift(ms_VM *vm) {
 
 static int ms_BoolBitwiseAnd(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b & r.val.i);
+        case MSVAL_INT:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b & r.val.i);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b & (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b & (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -1327,15 +1327,15 @@ static int ms_BoolBitwiseAnd(ms_VM *vm) {
 
 static int ms_BoolBitwiseXor(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b ^ r.val.i);
+        case MSVAL_INT:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b ^ r.val.i);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b ^ (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b ^ (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -1344,15 +1344,15 @@ static int ms_BoolBitwiseXor(ms_VM *vm) {
 
 static int ms_BoolBitwiseOr(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b | r.val.i);
+        case MSVAL_INT:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b | r.val.i);
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, (ms_VMInt)l.val.b | (ms_VMInt)r.val.b);
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, (ms_ValInt)l.val.b | (ms_ValInt)r.val.b);
             return 1;
         default:
             return 0;
@@ -1361,26 +1361,26 @@ static int ms_BoolBitwiseOr(ms_VM *vm) {
 
 static int ms_BoolBitwiseNot(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
-    ms_VMPushInt(vm, ~((ms_VMInt)l.val.b));
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
+    ms_VMPushInt(vm, ~((ms_ValInt)l.val.b));
     return 1;
 }
 
 static int ms_BoolLessThan(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMInt)l.val.b < r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValInt)l.val.b < r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMFloat)l.val.b < r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValFloat)l.val.b < r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMInt)l.val.b < (ms_VMInt)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValInt)l.val.b < (ms_ValInt)r.val.b));
             return 1;
         default:
             return 0;
@@ -1389,18 +1389,18 @@ static int ms_BoolLessThan(ms_VM *vm) {
 
 static int ms_BoolLessEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMInt)l.val.b <= r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValInt)l.val.b <= r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMFloat)l.val.b <= r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValFloat)l.val.b <= r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMInt)l.val.b <= (ms_VMInt)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValInt)l.val.b <= (ms_ValInt)r.val.b));
             return 1;
         default:
             return 0;
@@ -1409,18 +1409,18 @@ static int ms_BoolLessEqual(ms_VM *vm) {
 
 static int ms_BoolGreaterThan(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMInt)l.val.b > r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValInt)l.val.b > r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMFloat)l.val.b > r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValFloat)l.val.b > r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMInt)l.val.b > (ms_VMInt)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValInt)l.val.b > (ms_ValInt)r.val.b));
             return 1;
         default:
             return 0;
@@ -1429,18 +1429,18 @@ static int ms_BoolGreaterThan(ms_VM *vm) {
 
 static int ms_BoolGreaterEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMInt)l.val.b >= r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValInt)l.val.b >= r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMFloat)l.val.b >= r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValFloat)l.val.b >= r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMInt)l.val.b >= (ms_VMInt)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValInt)l.val.b >= (ms_ValInt)r.val.b));
             return 1;
         default:
             return 0;
@@ -1449,18 +1449,18 @@ static int ms_BoolGreaterEqual(ms_VM *vm) {
 
 static int ms_BoolEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMInt)l.val.b == r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValInt)l.val.b == r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMFloat)l.val.b == r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValFloat)l.val.b == r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMInt)l.val.b == (ms_VMInt)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValInt)l.val.b == (ms_ValInt)r.val.b));
             return 1;
         default:
             return 0;
@@ -1469,18 +1469,18 @@ static int ms_BoolEqual(ms_VM *vm) {
 
 static int ms_BoolNotEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     switch (r.type) {
-        case VMVAL_INT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMInt)l.val.b != r.val.i));
+        case MSVAL_INT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValInt)l.val.b != r.val.i));
             return 1;
-        case VMVAL_FLOAT:
-            ms_VMPushBool(vm, (ms_VMBool)((ms_VMFloat)l.val.b != r.val.f));
+        case MSVAL_FLOAT:
+            ms_VMPushBool(vm, (ms_ValBool)((ms_ValFloat)l.val.b != r.val.f));
             return 1;
-        case VMVAL_BOOL:
-            ms_VMPushInt(vm, (ms_VMBool)((ms_VMInt)l.val.b != (ms_VMInt)r.val.b));
+        case MSVAL_BOOL:
+            ms_VMPushInt(vm, (ms_ValBool)((ms_ValInt)l.val.b != (ms_ValInt)r.val.b));
             return 1;
         default:
             return 0;
@@ -1489,17 +1489,17 @@ static int ms_BoolNotEqual(ms_VM *vm) {
 
 static int ms_BoolNot(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
-    ms_VMPushBool(vm, !((ms_VMBool)l.val.b));
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
+    ms_VMPushBool(vm, !((ms_ValBool)l.val.b));
     return 1;
 }
 
 static int ms_BoolAnd(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
 
     ms_VMPush(vm, r);
     ms_Function tobool = ms_VMPrototypeFuncGet(vm, r.type, "__bool__");
@@ -1515,9 +1515,9 @@ static int ms_BoolAnd(ms_VM *vm) {
 
 static int ms_BoolOr(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_BOOL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_BOOL);
     if (l.val.b) {
         ms_VMPushBool(vm, true);
         return 1;
@@ -1541,58 +1541,58 @@ static int ms_BoolOr(ms_VM *vm) {
 
 static int ms_NullToStr(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_NULL);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_NULL);
     ms_VMPushStrL(vm, "null", 4);
     return 1;
 }
 
 static int ms_NullToFloat(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_NULL);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_NULL);
     ms_VMPushFloat(vm, 0.0);
     return 1;
 }
 
 static int ms_NullToInt(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_NULL);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_NULL);
     ms_VMPushInt(vm, 0);
     return 1;
 }
 
 static int ms_NullToBool(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_NULL);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_NULL);
     ms_VMPushBool(vm, false);
     return 1;
 }
 
 static int ms_NullEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_NULL);
-    ms_VMPushBool(vm, (ms_VMBool)(r.type == VMVAL_NULL));
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_NULL);
+    ms_VMPushBool(vm, (ms_ValBool)(r.type == MSVAL_NULL));
     return 1;
 }
 
 static int ms_NullNotEqual(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_NULL);
-    ms_VMPushBool(vm, (ms_VMBool)(r.type != VMVAL_NULL));
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_NULL);
+    ms_VMPushBool(vm, (ms_ValBool)(r.type != MSVAL_NULL));
     return 1;
 }
 
 static int ms_NullNot(ms_VM *vm) {
     assert(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_NULL);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_NULL);
     ms_VMPushBool(vm, true);
     return 1;
 }
@@ -1600,17 +1600,17 @@ static int ms_NullNot(ms_VM *vm) {
 static int ms_NullAnd(ms_VM *vm) {
     assert(vm);
     (void)ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_NULL);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_NULL);
     ms_VMPushBool(vm, false);
     return 1;
 }
 
 static int ms_NullOr(ms_VM *vm) {
     assert(vm);
-    ms_VMValue r = ms_VMPop(vm);
-    ms_VMValue l = ms_VMPop(vm);
-    assert(l.type == VMVAL_NULL);
+    ms_Value r = ms_VMPop(vm);
+    ms_Value l = ms_VMPop(vm);
+    assert(l.type == MSVAL_NULL);
 
     ms_VMPush(vm, r);
     ms_Function tobool = ms_VMPrototypeFuncGet(vm, r.type, "__bool__");

--- a/src/parser.c
+++ b/src/parser.c
@@ -825,9 +825,9 @@ static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
 
             /* string literals */
         case STRING: {
-            ms_VMData p;
+            ms_ValData p;
             p.s = cur->value;
-            *expr = ms_ExprNewWithVal(VMVAL_STR, p);
+            *expr = ms_ExprNewWithVal(MSVAL_STR, p);
             if (!(*expr)) {
                 ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
                 res = PARSE_ERROR;
@@ -839,9 +839,9 @@ static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
             /* boolean literals */
         case KW_TRUE:
         case KW_FALSE: {
-            ms_VMData p;
+            ms_ValData p;
             p.b = (cur->type == KW_TRUE) ? true : false;
-            *expr = ms_ExprNewWithVal(VMVAL_BOOL, p);
+            *expr = ms_ExprNewWithVal(MSVAL_BOOL, p);
             if (!(*expr)) {
                 ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
                 res = PARSE_ERROR;
@@ -851,9 +851,9 @@ static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
 
             /* null literal */
         case KW_NULL: {
-            ms_VMData p;
+            ms_ValData p;
             p.n = MS_VM_NULL_POINTER;
-            *expr = ms_ExprNewWithVal(VMVAL_NULL, p);
+            *expr = ms_ExprNewWithVal(MSVAL_NULL, p);
             if (!(*expr)) {
                 ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
                 res = PARSE_ERROR;
@@ -864,7 +864,7 @@ static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
             /* reference an identifier (either builtin or other identifier) */
         case IDENTIFIER:
         case BUILTIN_FUNC: {
-            *expr = ms_ExprNewWithIdent(dsbuf_char_ptr(cur->value));
+            *expr = ms_ExprNewWithIdent(dsbuf_char_ptr(cur->value), dsbuf_len(cur->value));
             if (!(*expr)) {
                 ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
                 res = PARSE_ERROR;

--- a/src/parser.c
+++ b/src/parser.c
@@ -51,16 +51,19 @@ static const char *const ERR_EXPECTING_TOK_GOT_TOK = "Expecting '%s', got '%s' (
 static const char *const ERR_INVALID_SYNTAX_GOT_TOK = "Invalid syntax '%s' (ln: %d, col: %d)";
 
 static ms_ParseResult ParserParseExpression(ms_Parser *prs, ms_Expr **expr);
+static ms_ParseResult ParserParseExprRecursive(ms_Parser *prs, ms_Token *prev, DSArray *exprstack, DSArray *opstack);
 static bool ParserExprShouldCombine(ms_Parser *prs, ms_Token *top, ms_Token *next);
 static ms_ParseResult ParserExprCombine(ms_Parser *prs, DSArray *exprstack, ms_Token *tok);
 static ms_ParseResult ParserExprCombineUnary(ms_Parser *prs, DSArray *exprstack, ms_Token *tok, ms_ExprUnaryOp op);
 static ms_ParseResult ParserExprCombineBinary(ms_Parser *prs, DSArray *exprstack, ms_Token *tok, ms_ExprBinaryOp op);
+static ms_ParseResult ParserParseFunctionCall(ms_Parser *prs, ms_Expr **fcall);
 static inline ms_Token *ParserCurrentToken(ms_Parser *prs);
 static inline ms_Token *ParserNextToken(ms_Parser *prs);
 static inline ms_Token *ParserAdvanceToken(ms_Parser *prs);
 static inline void ParserConsumeToken(ms_Parser *prs);
 static bool ParserExpectToken(ms_Parser *prs, ms_TokenType type);
 static bool ParserConstructOpCache(ms_Parser *prs);
+static ms_ParseError *ParseErrorNew(const char *msg, const ms_Token *tok, ...);
 static void ParserErrorSet(ms_Parser *prs, const char* msg, const ms_Token *tok, ...);
 static void ParseErrorDestroy(ms_ParseError *err);
 
@@ -200,6 +203,8 @@ static ms_ParseResult ParserParseExpression(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
+    *expr = NULL;
+
     /* stack for staging intermediate expressions */
     DSArray *exprstack = dsarray_new_cap(EXPRESSION_STACK_DEFAULT_LEN,
                                          NULL, (dsarray_free_fn)ms_ExprDestroy);
@@ -217,196 +222,11 @@ static ms_ParseResult ParserParseExpression(ms_Parser *prs, ms_Expr **expr) {
         return PARSE_ERROR;
     }
 
-    /* perform the Shunting Yard algorithm to create the AST */
-    ms_TokenType prevtype = ERROR;
-    ms_ParseResult res = PARSE_SUCCESS;
-    for (ms_Token *cur = ParserCurrentToken(prs), *prev = NULL; cur;
-            prev = cur, cur = ParserCurrentToken(prs)) {
-        /* by default, consume (destroy) the current token and advance the
-         * pointer; individual cases override this if the token should not
-         * be destroyed immediately */
-        void (*cleanup_token)(ms_Parser *) = ParserConsumeToken;
-
-        switch (cur->type) {
-                /* floating point number literals */
-            case FLOAT_NUMBER: {
-                const char *val = dsbuf_char_ptr(cur->value);
-                ms_Expr *newexpr = ms_ExprFloatFromString(val);
-                if (!newexpr) {
-                    ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
-                    res = PARSE_ERROR;
-                    goto parse_expr_cleanup;
-                }
-                dsarray_append(exprstack, newexpr);
-                break;
-            }
-
-                /* integer literals */
-            case INT_NUMBER:
-            case HEX_NUMBER: {
-                const char *val = dsbuf_char_ptr(cur->value);
-                ms_Expr *newexpr = ms_ExprIntFromString(val);
-                if (!newexpr) {
-                    ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
-                    res = PARSE_ERROR;
-                    goto parse_expr_cleanup;
-                }
-                dsarray_append(exprstack, newexpr);
-                break;
-            }
-
-                /* string literals */
-            case STRING: {
-                ms_VMData p;
-                p.s = cur->value;
-                ms_Expr *newexpr = ms_ExprNewWithVal(VMVAL_STR, p);
-                if (!newexpr) {
-                    ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
-                    res = PARSE_ERROR;
-                    goto parse_expr_cleanup;
-                }
-                cur->value = NULL; /* prevent the buffer being destroyed when the token is destroyed */
-                dsarray_append(exprstack, newexpr);
-                break;
-            }
-
-                /* boolean literals */
-            case KW_TRUE:
-            case KW_FALSE: {
-                ms_VMData p;
-                p.b = (cur->type == KW_TRUE) ? true : false;
-                ms_Expr *newexpr = ms_ExprNewWithVal(VMVAL_BOOL, p);
-                if (!newexpr) {
-                    ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
-                    res = PARSE_ERROR;
-                    goto parse_expr_cleanup;
-                }
-                dsarray_append(exprstack, newexpr);
-                break;
-            }
-
-                /* null literal */
-            case KW_NULL: {
-                ms_VMData p;
-                p.n = MS_VM_NULL_POINTER;
-                ms_Expr *newexpr = ms_ExprNewWithVal(VMVAL_NULL, p);
-                if (!newexpr) {
-                    ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
-                    res = PARSE_ERROR;
-                    goto parse_expr_cleanup;
-                }
-                dsarray_append(exprstack, newexpr);
-                break;
-            }
-
-                /* begin parenthesized expression */
-            case LPAREN: {
-                dsarray_append(opstack, cur);
-                cleanup_token = (void (*)(ms_Parser *)) ParserAdvanceToken;       /* leave reference to token */
-                break;
-            }
-
-                /* attempt to complete the parenthesized expression */
-            case RPAREN: {
-                bool found = false;
-                while (dsarray_len(opstack) > 0) {
-                    ms_Token *tok = dsarray_top(opstack);
-                    if (tok->type != LPAREN) {
-                        tok = dsarray_pop(opstack);
-                        if ((res = ParserExprCombine(prs, exprstack, tok)) == PARSE_ERROR) {
-                            goto parse_expr_cleanup;
-                        }
-                        ms_TokenDestroy(tok);
-                    } else {
-                        found = true;
-                        ms_Token *op = dsarray_pop(opstack);
-                        ms_TokenDestroy(op);
-                        break;
-                    }
-                }
-                if (!found) {
-                    ParserErrorSet(prs, ERR_MISMATCHED_PARENS, cur, cur->line, cur->col);
-                    res = PARSE_ERROR;
-                    goto parse_expr_cleanup;
-                }
-                break;
-            }
-
-                /* determine if these unary operators are to the LEFT of their operand */
-            case OP_BITWISE_NOT:
-            case OP_NOT: {
-                if ((prev) && (!ms_TokenTypeIsOp(prevtype)) && (prevtype != LPAREN)) {
-                    ParserErrorSet(prs, ERR_EXPECTED_OPERAND, cur, cur->line, cur->col);
-                    res = PARSE_ERROR;
-                    goto parse_expr_cleanup;
-                }
-                goto parse_expr_evaluate_op;
-            }
-                /* determine if this is a unary or binary minus sign */
-            case OP_MINUS: {
-                if ((!prev) || (ms_TokenTypeIsOp(prevtype)) || (prevtype == LPAREN)) {
-                    cur->type = OP_UMINUS;
-                    dsarray_append(opstack, cur);
-                    cleanup_token = (void (*)(ms_Parser *)) ParserAdvanceToken;       /* leave reference to token */
-                    break;
-                }
-                goto parse_expr_evaluate_op;    /* in case this case gets separated from below */
-            }
-
-            /* goto label for unary minus, logical not, bitwise not operators */
-parse_expr_evaluate_op:
-
-                /* evaluate standard binary operators */
-            case OP_PLUS:
-            case OP_TIMES:
-            case OP_DIVIDE:
-            case OP_IDIVIDE:
-            case OP_MODULO:
-            case OP_EXPONENTIATE:
-            case OP_SHIFT_LEFT:
-            case OP_SHIFT_RIGHT:
-            case OP_BITWISE_AND:
-            case OP_BITWISE_OR:
-            case OP_BITWISE_XOR:
-            case OP_LE:
-            case OP_LT:
-            case OP_GE:
-            case OP_GT:
-            case OP_DOUBLE_EQ:
-            case OP_EQ:
-            case OP_NOT_EQ:
-            case OP_AND:
-            case OP_OR: {
-                ms_Token *top = dsarray_top(opstack);
-                if ((dsarray_len(opstack) > 0) && ParserExprShouldCombine(prs, top, cur)) {
-                    top = dsarray_pop(opstack);
-                    if ((res = ParserExprCombine(prs, exprstack, top)) == PARSE_ERROR) {
-                        goto parse_expr_cleanup;
-                    }
-                    ms_TokenDestroy(top);
-                }
-                dsarray_append(opstack, cur);
-                cleanup_token = (void (*)(ms_Parser *)) ParserAdvanceToken;       /* leave reference to token */
-                break;
-            }
-                /* newlines outside of parens, braces, and brackets indicate EOL */
-            case NEWLINE:
-                goto parse_expr_end_of_expr;
-
-                /* handle erroneous tokens in the input */
-            default:
-                ParserErrorSet(prs, ERR_INVALID_SYNTAX_GOT_TOK, cur,
-                               dsbuf_char_ptr(cur->value), cur->line, cur->col);
-                res = PARSE_ERROR;
-                goto parse_expr_cleanup;
-        }
-
-        prevtype = cur->type;
-        cleanup_token(prs);
+    /* begin parsing the expression */
+    ms_ParseResult res = ParserParseExprRecursive(prs, NULL, exprstack, opstack);
+    if (res == PARSE_ERROR) {
+        goto parse_expr_cleanup;
     }
-
-    /* goto label for a newline in an expression */
-parse_expr_end_of_expr:
 
     /* drain the rest of the operators on the stack */
     while (dsarray_len(opstack) > 0) {
@@ -436,6 +256,244 @@ parse_expr_end_of_expr:
 parse_expr_cleanup:
     dsarray_destroy(opstack);
     dsarray_destroy(exprstack);
+    return res;
+}
+
+// Recursive call for parsing expression pieces
+static ms_ParseResult ParserParseExprRecursive(ms_Parser *prs, ms_Token *prev, DSArray *exprstack, DSArray *opstack) {
+    assert(prs);
+    assert(exprstack);
+    assert(opstack);
+
+    ms_ParseResult res = PARSE_SUCCESS;
+    ms_Token *cur = ParserCurrentToken(prs);
+    if (!cur) { return PARSE_SUCCESS; }
+
+    /* by default, consume (destroy) the current token and advance the
+     * pointer; individual cases override this if the token should not
+     * be destroyed immediately */
+    bool cleanup_token = true;
+
+    switch (cur->type) {
+            /* floating point number literals */
+        case FLOAT_NUMBER: {
+            const char *val = dsbuf_char_ptr(cur->value);
+            ms_Expr *newexpr = ms_ExprFloatFromString(val);
+            if (!newexpr) {
+                ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
+                res = PARSE_ERROR;
+                goto parse_expr_end_of_expr;
+            }
+            dsarray_append(exprstack, newexpr);
+            break;
+        }
+
+            /* integer literals */
+        case INT_NUMBER:
+        case HEX_NUMBER: {
+            const char *val = dsbuf_char_ptr(cur->value);
+            ms_Expr *newexpr = ms_ExprIntFromString(val);
+            if (!newexpr) {
+                ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
+                res = PARSE_ERROR;
+                goto parse_expr_end_of_expr;
+            }
+            dsarray_append(exprstack, newexpr);
+            break;
+        }
+
+            /* string literals */
+        case STRING: {
+            ms_VMData p;
+            p.s = cur->value;
+            ms_Expr *newexpr = ms_ExprNewWithVal(VMVAL_STR, p);
+            if (!newexpr) {
+                ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
+                res = PARSE_ERROR;
+                goto parse_expr_end_of_expr;
+            }
+            cur->value = NULL; /* prevent the buffer being destroyed when the token is destroyed */
+            dsarray_append(exprstack, newexpr);
+            break;
+        }
+
+            /* boolean literals */
+        case KW_TRUE:
+        case KW_FALSE: {
+            ms_VMData p;
+            p.b = (cur->type == KW_TRUE) ? true : false;
+            ms_Expr *newexpr = ms_ExprNewWithVal(VMVAL_BOOL, p);
+            if (!newexpr) {
+                ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
+                res = PARSE_ERROR;
+                goto parse_expr_end_of_expr;
+            }
+            dsarray_append(exprstack, newexpr);
+            break;
+        }
+
+            /* null literal */
+        case KW_NULL: {
+            ms_VMData p;
+            p.n = MS_VM_NULL_POINTER;
+            ms_Expr *newexpr = ms_ExprNewWithVal(VMVAL_NULL, p);
+            if (!newexpr) {
+                ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
+                res = PARSE_ERROR;
+                goto parse_expr_end_of_expr;
+            }
+            dsarray_append(exprstack, newexpr);
+            break;
+        }
+
+            /* reference an identifier (either builtin or other identifier) */
+        case IDENTIFIER:
+        case BUILTIN_FUNC: {
+            ms_Token *nxt = ParserNextToken(prs);
+            if (nxt) {
+                /* function call */
+                if (nxt->type == LPAREN) {
+                    ms_Expr *fcall;
+                    if ((res = ParserParseFunctionCall(prs, &fcall)) == PARSE_ERROR) {
+                        goto parse_expr_end_of_expr;
+                    }
+                    dsarray_append(exprstack, fcall);
+                }
+            }
+            break;
+        }
+
+            /* begin parenthesized expression */
+        case LPAREN: {
+            dsarray_append(opstack, cur);
+            ParserAdvanceToken(prs);
+
+            /* recursively parse the inner expression */
+            if ((res = ParserParseExprRecursive(prs, cur, exprstack, opstack)) == PARSE_ERROR) {
+                goto parse_expr_end_of_expr;
+            }
+
+            /* expect the closing paren */
+            if (!ParserExpectToken(prs, RPAREN)) {
+                ParserErrorSet(prs, ERR_MISMATCHED_PARENS, cur, cur->line, cur->col);
+                res = PARSE_ERROR;
+                goto parse_expr_end_of_expr;
+            }
+
+            /* drain the stack looking for the matching LPAREN and combining
+             * any intermediate expressions along the way */
+            bool found = false;
+            while (dsarray_len(opstack) > 0) {
+                ms_Token *tok = dsarray_top(opstack);
+                if (tok->type != LPAREN) {
+                    tok = dsarray_pop(opstack);
+                    if ((res = ParserExprCombine(prs, exprstack, tok)) == PARSE_ERROR) {
+                        assert(false);
+                    }
+                    ms_TokenDestroy(tok);
+                } else {
+                    found = true;
+                    ms_Token *op = dsarray_pop(opstack);
+                    ms_TokenDestroy(op);
+                    break;
+                }
+            }
+            if (!found) {
+                ParserErrorSet(prs, ERR_MISMATCHED_PARENS, cur, cur->line, cur->col);
+                res = PARSE_ERROR;
+                goto parse_expr_end_of_expr;
+            }
+
+            cleanup_token = false;
+            break;
+        }
+
+            /* the calling function should always deal with a closing paren */
+        case RPAREN:
+            goto parse_expr_end_of_expr;
+
+            /* determine if these unary operators are to the LEFT of their operand */
+        case OP_BITWISE_NOT:
+        case OP_NOT: {
+            if ((prev) && (!ms_TokenTypeIsOp(prev->type)) && (prev->type != LPAREN)) {
+                ParserErrorSet(prs, ERR_EXPECTED_OPERAND, cur, cur->line, cur->col);
+                res = PARSE_ERROR;
+                goto parse_expr_end_of_expr;
+            }
+            goto parse_expr_evaluate_op;
+        }
+            /* determine if this is a unary or binary minus sign */
+        case OP_MINUS: {
+            if ((!prev) || (ms_TokenTypeIsOp(prev->type)) || (prev->type == LPAREN)) {
+                cur->type = OP_UMINUS;
+                dsarray_append(opstack, cur);
+                cleanup_token = false;              /* leave reference to token */
+                break;
+            }
+            goto parse_expr_evaluate_op;    /* in case this case gets separated from below */
+        }
+
+        /* goto label for unary minus, logical not, bitwise not operators */
+parse_expr_evaluate_op:
+
+            /* evaluate standard binary operators */
+        case OP_PLUS:
+        case OP_TIMES:
+        case OP_DIVIDE:
+        case OP_IDIVIDE:
+        case OP_MODULO:
+        case OP_EXPONENTIATE:
+        case OP_SHIFT_LEFT:
+        case OP_SHIFT_RIGHT:
+        case OP_BITWISE_AND:
+        case OP_BITWISE_OR:
+        case OP_BITWISE_XOR:
+        case OP_LE:
+        case OP_LT:
+        case OP_GE:
+        case OP_GT:
+        case OP_DOUBLE_EQ:
+        case OP_EQ:
+        case OP_NOT_EQ:
+        case OP_AND:
+        case OP_OR: {
+            ms_Token *top = dsarray_top(opstack);
+            if ((dsarray_len(opstack) > 0) && ParserExprShouldCombine(prs, top, cur)) {
+                top = dsarray_pop(opstack);
+                if ((res = ParserExprCombine(prs, exprstack, top)) == PARSE_ERROR) {
+                    goto parse_expr_end_of_expr;
+                }
+                ms_TokenDestroy(top);
+            }
+            dsarray_append(opstack, cur);
+            cleanup_token = false;                  /* leave reference to token */
+            break;
+        }
+
+            /* newlines outside of parens, braces, and brackets indicate EOL */
+        case NEWLINE:
+            goto parse_expr_end_of_expr;
+
+            /* reaching a comma probably means we're in another context
+             * (such as a function call) and we need to finish up and return */
+        case COMMA:
+            goto parse_expr_end_of_expr;
+
+            /* handle erroneous tokens in the input */
+        default:
+            ParserErrorSet(prs, ERR_INVALID_SYNTAX_GOT_TOK, cur,
+                           dsbuf_char_ptr(cur->value), cur->line, cur->col);
+            res = PARSE_ERROR;
+            goto parse_expr_end_of_expr;
+    }
+
+    /* attempt to continue parsing recursively */
+    ParserAdvanceToken(prs);
+    res = ParserParseExprRecursive(prs, cur, exprstack, opstack);
+    if (cleanup_token) { ms_TokenDestroy(cur); }
+
+    /* goto label for when there is no more expression */
+parse_expr_end_of_expr:
     return res;
 }
 
@@ -541,6 +599,50 @@ static ms_ParseResult ParserExprCombineBinary(ms_Parser *prs, DSArray *exprstack
     return PARSE_SUCCESS;
 }
 
+// Parse a function call in an expression.
+static ms_ParseResult ParserParseFunctionCall(ms_Parser *prs, ms_Expr **fcall) {
+    assert(prs);
+    assert(fcall);
+
+    ms_FuncType type = (prs->cur->type == BUILTIN_FUNC) ? FUNCTYPE_BUILTIN : FUNCTYPE_USER;
+    *fcall = ms_ExprNewWithFuncCall(dsbuf_char_ptr(prs->cur->value), type);
+    ParserAdvanceToken(prs); /* no need to destroy since it will be destroyed by caller */
+
+    /* opening paren */
+    if (!ParserExpectToken(prs, LPAREN)) {
+        ms_ExprDestroy(*fcall);
+        *fcall = NULL;
+        return PARSE_ERROR;
+    }
+
+    /* no parameters, close and return immediately */
+    if (prs->cur->type == RPAREN) {
+        return PARSE_SUCCESS;
+    }
+
+    /* opening paren */
+    while(ParserCurrentToken(prs)) {
+        ms_Expr *param;
+        if (ParserParseExpression(prs, &param) == PARSE_ERROR) {
+            ms_ExprDestroy(*fcall);
+            *fcall = NULL;
+            return PARSE_ERROR;
+        }
+        dsarray_append((*fcall)->expr.u->expr.fc.params, param);
+        if (ParserCurrentToken(prs) && ParserCurrentToken(prs)->type == RPAREN) {
+            break;
+        }
+    }
+
+    /* closing paren */
+    if (!ParserExpectToken(prs, RPAREN)) {
+        ms_ExprDestroy(*fcall);
+        *fcall = NULL;
+        return PARSE_ERROR;
+    }
+    return PARSE_SUCCESS;
+}
+
 // Look at the current token in the stream.
 static inline ms_Token *ParserCurrentToken(ms_Parser *prs) {
     assert(prs);
@@ -583,6 +685,7 @@ static bool ParserExpectToken(ms_Parser *prs, ms_TokenType type) {
                        ms_TokenName(prs->cur), prs->cur->line, prs->cur->col);
     }
 
+    ParserConsumeToken(prs);
     return (prs->err == NULL);
 }
 
@@ -607,8 +710,36 @@ static bool ParserConstructOpCache(ms_Parser *prs) {
     return true;
 }
 
-// Generate a new ParseError object.
-static void ParserErrorSet(ms_Parser *prs, const char* msg, const ms_Token *tok, ...) {
+// Create a new ParseError object.
+static ms_ParseError *ParseErrorNew(const char *msg, const ms_Token *tok, ...) {
+    ms_ParseError *err = malloc(sizeof(ms_ParseError));
+    if (!err) {
+        return NULL;
+    }
+
+    va_list args, args2;
+    va_start(args, tok);
+    va_copy(args2, args);
+
+    int len = vsnprintf(NULL, 0, msg, args);
+    err->msg = malloc((size_t)len + 1);
+    if (!err->msg) {
+        free(err);
+        return NULL;
+    }
+
+    vsnprintf(err->msg, len + 1, msg, args2);
+    err->tok = (tok) ?
+                ms_TokenNew(tok->type, dsbuf_char_ptr(tok->value),
+                            dsbuf_len(tok->value), tok->line, tok->col) :
+                NULL;
+    va_end(args);
+    va_end(args2);
+    return err;
+}
+
+// Generate a new ParseError object attached to the Parser.
+static void ParserErrorSet(ms_Parser *prs, const char *msg, const ms_Token *tok, ...) {
     assert(prs);
 
     if (prs->err) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -622,7 +622,7 @@ static ms_ParseResult ParserParseUnaryExpr(ms_Parser *prs, ms_Expr **expr) {
     ms_ParseResult res = PARSE_ERROR;
     *expr = NULL;
 
-    while (prs->cur) {
+    if (prs->cur) {
         ms_Token *cur = prs->cur;
         ms_ExprUnaryOp op;
         switch (cur->type) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -909,7 +909,7 @@ static ms_ParseResult ParserExprCombineBinary(ms_Parser *prs, ms_Expr *left, ms_
 
     *newexpr = ms_ExprFlatten(*newexpr, left, EXPRLOC_LEFT);
     *newexpr = ms_ExprFlatten(*newexpr, right, EXPRLOC_RIGHT);
-    (*newexpr)->expr.b->op = op;
+    (*newexpr)->cmpnt.b->op = op;
 
     return PARSE_SUCCESS;
 }
@@ -927,7 +927,7 @@ static ms_ParseResult ParserExprCombineUnary(ms_Parser *prs, ms_Expr *inner, ms_
     }
 
     *newexpr = ms_ExprFlatten(*newexpr, inner, EXPRLOC_UNARY);
-    (*newexpr)->expr.u->op = op;
+    (*newexpr)->cmpnt.u->op = op;
 
     return PARSE_SUCCESS;
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -18,6 +18,7 @@
 #define MSCRIPT_PARSER_H
 
 #include <stdbool.h>
+#include "bytecode.h"
 #include "lang.h"
 
 /**

--- a/src/vm.c
+++ b/src/vm.c
@@ -31,7 +31,7 @@
 #define VM_FRAME_STACK_LIMIT_L (256)
 static const int FRAME_DATA_STACK_LIMIT = FRAME_DATA_STACK_LIMIT_L;
 static const int VM_FRAME_STACK_LIMIT = VM_FRAME_STACK_LIMIT_L;
-static const ms_VMValue EMPTY_STACK_VAL;
+static const ms_Value EMPTY_STACK_VAL;
 
 static const int MS_VM_NULL = 0;
 const void *MS_VM_NULL_POINTER = &MS_VM_NULL;
@@ -40,7 +40,7 @@ typedef struct {
     size_t ip;                                      /* instruction pointer */
     size_t dp;                                      /* data stack pointer (points to index of NEXT push), current top is always (dp-1) */
     ms_VMByteCode *code;                            /* byte code for current frame */
-    ms_VMValue data[FRAME_DATA_STACK_LIMIT_L];      /* frame data stack */
+    ms_Value data[FRAME_DATA_STACK_LIMIT_L];      /* frame data stack */
 } ms_VMFrame;
 
 struct ms_VM {
@@ -59,7 +59,7 @@ static bool VMGeneratePrototypes(ms_VM *vm);
 static ms_VMFrame *VMFrameNew(ms_VMByteCode *bc);
 static void VMFrameDestroy(ms_VMFrame *f);
 static ms_VMExecResult VMFrameExecute(ms_VM *vm, ms_VMFrame *f);
-static ms_VMValue *VMPeek(ms_VM *vm, int index);
+static ms_Value *VMPeek(ms_VM *vm, int index);
 
 static inline size_t VMPrint(ms_VM *vm);
 static inline size_t VMPush(ms_VM *vm, int val);
@@ -132,7 +132,7 @@ ms_VMExecResult ms_VMExecuteAndPrint(ms_VM *vm, ms_VMByteCode *bc, const ms_VMEr
     return res;
 }
 
-ms_VMValue *ms_VMTop(ms_VM *vm) {
+ms_Value *ms_VMTop(ms_VM *vm) {
     assert(vm);
     assert(vm->fstack);
     ms_VMFrame *f = dsarray_top(vm->fstack);
@@ -141,13 +141,13 @@ ms_VMValue *ms_VMTop(ms_VM *vm) {
     return &f->data[f->dp - 1];
 }
 
-ms_VMValue ms_VMPop(ms_VM *vm) {
+ms_Value ms_VMPop(ms_VM *vm) {
     assert(vm);
     assert(vm->fstack);
     ms_VMFrame *f = dsarray_top(vm->fstack);
     assert(f);
     assert((f->dp - 1) != SIZE_MAX);
-    ms_VMValue val = f->data[f->dp - 1];
+    ms_Value val = f->data[f->dp - 1];
     f->data[f->dp] = EMPTY_STACK_VAL;
     f->dp--;
     return val;
@@ -169,7 +169,7 @@ void ms_VMErrorSet(ms_VM *vm, const char *msg, ...) {
     va_end(args);
 }
 
-void ms_VMPush(ms_VM *vm, ms_VMValue val) {
+void ms_VMPush(ms_VM *vm, ms_Value val) {
     assert(vm);
     assert(vm->fstack);
     ms_VMFrame *f = dsarray_top(vm->fstack);
@@ -179,26 +179,26 @@ void ms_VMPush(ms_VM *vm, ms_VMValue val) {
     f->dp++;
 }
 
-void ms_VMPushFloat(ms_VM *vm, ms_VMFloat f) {
+void ms_VMPushFloat(ms_VM *vm, ms_ValFloat f) {
     assert(vm);
-    ms_VMValue v;
-    v.type = VMVAL_FLOAT;
+    ms_Value v;
+    v.type = MSVAL_FLOAT;
     v.val.f = f;
     ms_VMPush(vm, v);
 }
 
-void ms_VMPushInt(ms_VM *vm, ms_VMInt i) {
+void ms_VMPushInt(ms_VM *vm, ms_ValInt i) {
     assert(vm);
-    ms_VMValue v;
-    v.type = VMVAL_INT;
+    ms_Value v;
+    v.type = MSVAL_INT;
     v.val.i = i;
     ms_VMPush(vm, v);
 }
 
-void ms_VMPushStr(ms_VM *vm, ms_VMStr *s) {
+void ms_VMPushStr(ms_VM *vm, ms_ValStr *s) {
     assert(vm);
-    ms_VMValue v;
-    v.type = VMVAL_STR;
+    ms_Value v;
+    v.type = MSVAL_STR;
     v.val.s = s;
     ms_VMPush(vm, v);
 }
@@ -207,24 +207,24 @@ void ms_VMPushStrL(ms_VM *vm, const char *s, size_t len) {
     assert(vm);
     DSBuffer *buf = dsbuf_new_l(s, len);
     if (!buf) { return; }
-    ms_VMValue v;
-    v.type = VMVAL_STR;
+    ms_Value v;
+    v.type = MSVAL_STR;
     v.val.s = buf;
     ms_VMPush(vm, v);
 }
 
-void ms_VMPushBool(ms_VM *vm, ms_VMBool b) {
+void ms_VMPushBool(ms_VM *vm, ms_ValBool b) {
     assert(vm);
-    ms_VMValue v;
-    v.type = VMVAL_BOOL;
+    ms_Value v;
+    v.type = MSVAL_BOOL;
     v.val.b = b;
     ms_VMPush(vm, v);
 }
 
 void ms_VMPushNull(ms_VM *vm) {
     assert(vm);
-    ms_VMValue v;
-    v.type = VMVAL_NULL;
+    ms_Value v;
+    v.type = MSVAL_NULL;
     v.val.n = MS_VM_NULL_POINTER;
     ms_VMPush(vm, v);
 }
@@ -233,7 +233,7 @@ void ms_VMSwap(ms_VM *vm) {
     (void) VMSwap(vm);
 }
 
-ms_Function ms_VMPrototypeFuncGet(ms_VM *vm, ms_VMDataType type, const char *method) {
+ms_Function ms_VMPrototypeFuncGet(ms_VM *vm, ms_ValDataType type, const char *method) {
     assert(vm);
     assert(vm->float_);
     assert(vm->int_);
@@ -243,19 +243,19 @@ ms_Function ms_VMPrototypeFuncGet(ms_VM *vm, ms_VMDataType type, const char *met
 
     ms_FuncDef *def;
     switch (type) {
-        case VMVAL_FLOAT:
+        case MSVAL_FLOAT:
             def = dsdict_get(vm->float_, (void *)method);
             return (def) ? def->func : NULL;
-        case VMVAL_INT:
+        case MSVAL_INT:
             def = dsdict_get(vm->int_, (void *)method);
             return (def) ? def->func : NULL;
-        case VMVAL_STR:
+        case MSVAL_STR:
             def = dsdict_get(vm->str, (void *)method);
             return (def) ? def->func : NULL;
-        case VMVAL_BOOL:
+        case MSVAL_BOOL:
             def = dsdict_get(vm->bool_, (void *)method);
             return (def) ? def->func : NULL;
-        case VMVAL_NULL:
+        case MSVAL_NULL:
             def = dsdict_get(vm->null, (void *)method);
             return (def) ? def->func : NULL;
     }
@@ -289,9 +289,9 @@ void ms_VMDestroy(ms_VM *vm) {
     free(vm);
 }
 
-bool ms_VMFloatIsInt(ms_VMFloat f, ms_VMInt *l) {
+bool ms_ValFloatIsInt(ms_ValFloat f, ms_ValInt *l) {
     if (fmod(f, 1.0) == 0.0) {
-        *l = (ms_VMInt) f;
+        *l = (ms_ValInt) f;
         return true;
     }
     *l = 0;
@@ -326,7 +326,7 @@ ms_VMByteCode *ms_VMByteCodeNew(const DSArray *opcodes, const DSArray *values, c
     }
 
     bc->nvals = dsarray_len((DSArray *)values);
-    bc->values = malloc(sizeof(ms_VMValue) * (bc->nvals));
+    bc->values = malloc(sizeof(ms_Value) * (bc->nvals));
     if (!bc->values) {
         free(bc->code);
         free(bc);
@@ -334,7 +334,7 @@ ms_VMByteCode *ms_VMByteCodeNew(const DSArray *opcodes, const DSArray *values, c
     }
 
     bc->nidents = dsarray_len((DSArray *)idents);
-    bc->idents = malloc(sizeof(ms_VMIdent *) * (bc->nidents));
+    bc->idents = malloc(sizeof(ms_Ident *) * (bc->nidents));
     if (!bc->idents) {
         free(bc->values);
         free(bc->code);
@@ -347,7 +347,7 @@ ms_VMByteCode *ms_VMByteCodeNew(const DSArray *opcodes, const DSArray *values, c
     }
 
     for (size_t i = 0; i < bc->nvals; i++) {
-        bc->values[i] = *(ms_VMValue *)dsarray_get((DSArray *)values, i);
+        bc->values[i] = *(ms_Value *)dsarray_get((DSArray *)values, i);
     }
 
     for (size_t i = 0; i < bc->nidents; i++) {
@@ -567,7 +567,7 @@ static ms_VMExecResult VMFrameExecute(ms_VM *vm, ms_VMFrame *f) {
 // Peek at a value a certain index of the stack without changing the pointer
 // Negative values are relative to the top with (-1) indicating top, non-zero
 // values indicate actual stack indices from the bottom (0)
-static ms_VMValue *VMPeek(ms_VM *vm, int index) {
+static ms_Value *VMPeek(ms_VM *vm, int index) {
     assert(vm);
     assert(vm->fstack);
     ms_VMFrame *f = dsarray_top(vm->fstack);
@@ -589,22 +589,22 @@ static ms_VMValue *VMPeek(ms_VM *vm, int index) {
 static inline size_t VMPrint(ms_VM *vm) {
     assert(vm);
     /* CHECK_VM_STACK(vm, 1); */
-    ms_VMValue *v = ms_VMTop(vm);
+    ms_Value *v = ms_VMTop(vm);
 
     switch (v->type) {
-        case VMVAL_FLOAT:
+        case MSVAL_FLOAT:
             printf("%f\n", v->val.f);
             break;
-        case VMVAL_INT:
+        case MSVAL_INT:
             printf("%lld\n", v->val.i);
             break;
-        case VMVAL_BOOL:
+        case MSVAL_BOOL:
             printf("%s\n", (v->val.b) ? "true" : "false");
             break;
-        case VMVAL_NULL:
+        case MSVAL_NULL:
             printf("null\n");
             break;
-        case VMVAL_STR:
+        case MSVAL_STR:
             printf("%s\n", dsbuf_char_ptr(v->val.s));
             break;
     }
@@ -634,8 +634,8 @@ static inline size_t VMPop(ms_VM *vm) {
 
 static inline size_t VMSwap(ms_VM *vm) {
     assert(vm);
-    ms_VMValue v2 = ms_VMPop(vm);
-    ms_VMValue v1 = ms_VMPop(vm);
+    ms_Value v2 = ms_VMPop(vm);
+    ms_Value v1 = ms_VMPop(vm);
     ms_VMPush(vm, v2);
     ms_VMPush(vm, v1);
     return 1;
@@ -643,7 +643,7 @@ static inline size_t VMSwap(ms_VM *vm) {
 
 static inline size_t VMDoBinaryOp(ms_VM *vm, const char *name) {
     assert(vm);
-    ms_VMValue *l = VMPeek(vm, -2);
+    ms_Value *l = VMPeek(vm, -2);
     ms_Function op = ms_VMPrototypeFuncGet(vm, l->type, name);
     if (!op) {
         ms_VMErrorSet(vm, "Method '%s' not supported for this object.", name);
@@ -655,7 +655,7 @@ static inline size_t VMDoBinaryOp(ms_VM *vm, const char *name) {
 
 static inline size_t VMDoUnaryOp(ms_VM *vm, const char *name) {
     assert(vm);
-    ms_VMValue *l = VMPeek(vm, -1);
+    ms_Value *l = VMPeek(vm, -1);
     ms_Function op = ms_VMPrototypeFuncGet(vm, l->type, name);
     if (!op) {
         ms_VMErrorSet(vm, "Method '%s' not supported for this object.", name);
@@ -667,7 +667,7 @@ static inline size_t VMDoUnaryOp(ms_VM *vm, const char *name) {
 
 static inline size_t VMCallFunction(ms_VM *vm) {
     assert(vm);
-    ms_VMValue *l = VMPeek(vm, -1);
+    ms_Value *l = VMPeek(vm, -1);
     ms_Function op = ms_VMPrototypeFuncGet(vm, l->type, "__call__");
     if (!op) {
         ms_VMErrorSet(vm, "Object is not callable.");
@@ -682,7 +682,7 @@ static inline size_t VMLoadName(ms_VM *vm, int arg) {
     assert(vm->fstack);
     ms_VMFrame *f = dsarray_top(vm->fstack);
     assert(f->code);
-    ms_VMIdent *id = f->code->idents[arg];
+    ms_Ident *id = f->code->idents[arg];
     assert(id);
     return 1;
 }

--- a/src/vm.h
+++ b/src/vm.h
@@ -20,6 +20,8 @@
 #include <stdbool.h>
 #include "libds/array.h"
 #include "libds/buffer.h"
+#include "bytecode.h"
+#include "lang.h"
 
 /**
 * @brief Virtual machine object for executing mscript byte code
@@ -55,105 +57,9 @@ typedef struct {
 } ms_VMError;
 
 /**
-* @brief Enumeration of mscript VM opcodes
-*/
-typedef enum {
-    OPC_PRINT,
-    OPC_PUSH,
-    OPC_POP,
-    OPC_SWAP,
-    OPC_ADD,
-    OPC_SUBTRACT,
-    OPC_MULTIPLY,
-    OPC_DIVIDE,
-    OPC_IDIVIDE,
-    OPC_MODULO,
-    OPC_EXPONENTIATE,
-    OPC_NEGATE,
-    OPC_SHIFT_LEFT,
-    OPC_SHIFT_RIGHT,
-    OPC_BITWISE_AND,
-    OPC_BITWISE_XOR,
-    OPC_BITWISE_OR,
-    OPC_BITWISE_NOT,
-    OPC_LE,
-    OPC_LT,
-    OPC_GE,
-    OPC_GT,
-    OPC_EQ,
-    OPC_NOT_EQ,
-    OPC_NOT,
-    OPC_AND,
-    OPC_OR,
-    OPC_CALL,
-    OPC_LOAD_NAME,
-} ms_VMOpCodeType;
-
-/**
 * @brief The explicit NULL pointer for the mscript VM.
 */
 extern const void *MS_VM_NULL_POINTER;
-
-/**
-* @brief Identifier
-*/
-typedef DSBuffer ms_VMIdent;
-
-/*
-* @brief Typedefs of VM values
-*/
-typedef double ms_VMFloat;
-typedef long long ms_VMInt;
-typedef DSBuffer ms_VMStr;
-typedef bool ms_VMBool;
-typedef const void ms_VMNull;
-
-/**
-* @brief Enumeration of data value types in the mscript VM
-*/
-typedef enum {
-    VMVAL_FLOAT,
-    VMVAL_INT,
-    VMVAL_STR,
-    VMVAL_BOOL,
-    VMVAL_NULL,
-} ms_VMDataType;
-
-/**
-* @brief Union of data types in the mscript VM
-*/
-typedef union {
-    ms_VMFloat f;
-    ms_VMInt i;
-    ms_VMStr *s;
-    ms_VMBool b;
-    ms_VMNull *n;
-} ms_VMData;
-
-/**
-* @brief Placeholder for a more sophisticated object-value in the mscript VM
-*/
-typedef struct {
-    ms_VMDataType type;
-    ms_VMData val;
-} ms_VMValue;
-
-/**
-* @brief Opcode value
-*/
-typedef int ms_VMOpCode;
-
-/**
-* @brief Container for a full mscript bytecode script
-*/
-typedef struct {
-    ms_VMOpCode *code;                              /* array of opcodes */
-    ms_VMValue *values;                             /* array of VM values */
-    ms_VMIdent **idents;                            /* array of identifiers */
-    size_t nops;                                    /* number of opcodes */
-    size_t nvals;                                   /* number of values */
-    size_t nidents;                                 /* number of idents */
-} ms_VMByteCode;
 
 /**
 * @brief Create a new mscript VM.
@@ -179,12 +85,12 @@ ms_VMExecResult ms_VMExecuteAndPrint(ms_VM *vm, ms_VMByteCode *bc, const ms_VMEr
 /**
 * @brief Peek at the top data value on the current VM frame.
 */
-ms_VMValue *ms_VMTop(ms_VM *vm);
+ms_Value *ms_VMTop(ms_VM *vm);
 
 /*
 * @brief Pop the top value off the data stack on the current VM frame.
 */
-ms_VMValue ms_VMPop(ms_VM *vm);
+ms_Value ms_VMPop(ms_VM *vm);
 
 /**
 * @brief Set the VM error message.
@@ -194,22 +100,22 @@ void ms_VMErrorSet(ms_VM *vm, const char *msg, ...);
 /*
 * @brief Push a new value onto the data stack of the current VM frame.
 */
-void ms_VMPush(ms_VM *vm, ms_VMValue val);
+void ms_VMPush(ms_VM *vm, ms_Value val);
 
 /*
 * @brief Push a floating point value onto the stack.
 */
-void ms_VMPushFloat(ms_VM *vm, ms_VMFloat f);
+void ms_VMPushFloat(ms_VM *vm, ms_ValFloat f);
 
 /*
 * @brief Push an integer value onto the stack.
 */
-void ms_VMPushInt(ms_VM *vm, ms_VMInt i);
+void ms_VMPushInt(ms_VM *vm, ms_ValInt i);
 
 /*
 * @brief Push a string onto the stack.
 */
-void ms_VMPushStr(ms_VM *vm, ms_VMStr *s);
+void ms_VMPushStr(ms_VM *vm, ms_ValStr *s);
 
 /*
 * @brief Push a C string onto the stack.
@@ -219,7 +125,7 @@ void ms_VMPushStrL(ms_VM *vm, const char *s, size_t len);
 /*
 * @brief Push a boolean value onto the stack.
 */
-void ms_VMPushBool(ms_VM *vm, ms_VMBool b);
+void ms_VMPushBool(ms_VM *vm, ms_ValBool b);
 
 /*
 * @brief Push a null value onto the stack.
@@ -234,7 +140,7 @@ void ms_VMSwap(ms_VM *vm);
 /**
 * @brief Get a function pointer for the given primitive type and method.
 */
-ms_Function ms_VMPrototypeFuncGet(ms_VM *vm, ms_VMDataType type, const char *method);
+ms_Function ms_VMPrototypeFuncGet(ms_VM *vm, ms_ValDataType type, const char *method);
 
 /**
 * @brief Clear the data stack and reset the instruction pointer.
@@ -257,7 +163,7 @@ void ms_VMDestroy(ms_VM *vm);
 * @param l a pointer to an integer which will be filled if @c f contains an int
 * @returns true if @c f contains an integer; false otherwise
 */
-bool ms_VMFloatIsInt(ms_VMFloat f, ms_VMInt *l);
+bool ms_VMFloatIsInt(ms_ValFloat f, ms_ValInt *l);
 
 /**
 * @brief Encode an opcode with a numeric argument.
@@ -279,8 +185,8 @@ ms_VMOpCodeType ms_VMOpCodeGetCode(ms_VMOpCode c);
 * @c ms_VMByteCode container.
 *
 * @param opcodes a @c DSArray with all @c ms_VMOpCode objects
-* @param values a @c DSArray with all @c ms_VMValues
-* @param idents a @c DSArray with all @c ms_VMIdent
+* @param values a @c DSArray with all @c ms_Values
+* @param idents a @c DSArray with all @c ms_Ident
 * @returns an @c ms_VMByteCode container suitable for execution by the VM
 */
 ms_VMByteCode *ms_VMByteCodeNew(const DSArray *opcodes, const DSArray *values, const DSArray *idents);

--- a/src/vm.h
+++ b/src/vm.h
@@ -85,12 +85,19 @@ typedef enum {
     OPC_NOT,
     OPC_AND,
     OPC_OR,
+    OPC_CALL,
+    OPC_LOAD_NAME,
 } ms_VMOpCodeType;
 
 /**
 * @brief The explicit NULL pointer for the mscript VM.
 */
 extern const void *MS_VM_NULL_POINTER;
+
+/**
+* @brief Identifier
+*/
+typedef DSBuffer ms_VMIdent;
 
 /*
 * @brief Typedefs of VM values
@@ -142,8 +149,10 @@ typedef int ms_VMOpCode;
 typedef struct {
     ms_VMOpCode *code;                              /* array of opcodes */
     ms_VMValue *values;                             /* array of VM values */
+    ms_VMIdent **idents;                            /* array of identifiers */
     size_t nops;                                    /* number of opcodes */
     size_t nvals;                                   /* number of values */
+    size_t nidents;                                 /* number of idents */
 } ms_VMByteCode;
 
 /**
@@ -269,10 +278,12 @@ ms_VMOpCodeType ms_VMOpCodeGetCode(ms_VMOpCode c);
 * @brief Convert a stack consisting of ms_VMOpCodes into a single
 * @c ms_VMByteCode container.
 *
-* @param stack a @c DSArray with all @c ms_VMOpCode objects
+* @param opcodes a @c DSArray with all @c ms_VMOpCode objects
+* @param values a @c DSArray with all @c ms_VMValues
+* @param idents a @c DSArray with all @c ms_VMIdent
 * @returns an @c ms_VMByteCode container suitable for execution by the VM
 */
-ms_VMByteCode *ms_VMByteCodeNew(const DSArray *opcodes, const DSArray *values);
+ms_VMByteCode *ms_VMByteCodeNew(const DSArray *opcodes, const DSArray *values, const DSArray *idents);
 
 /**
 * @brief Destroy the memory held by byte code.

--- a/test/lexer.c
+++ b/test/lexer.c
@@ -166,7 +166,7 @@ MunitResult lex_TestLexPunctuation(const MunitParameter params[], void *user_dat
 
 MunitResult lex_TestLexNewlines(const MunitParameter params[], void *user_data) {
     const char *newline = munit_parameters_get(params, "newline");
-    return LexExpect(newline, NEWLINE);
+    return LexExpect(newline, NEWLINE_TOK);
 }
 
 MunitResult lex_TestLexStrings(const MunitParameter params[], void *user_data) {

--- a/test/lexer.c
+++ b/test/lexer.c
@@ -207,6 +207,7 @@ MunitResult TestLexResultTuple(LexResultTuple *tokens, size_t len) {
 
     for (size_t i = 0; i < len; i++) {
         LexResultTuple *tuple = &tokens[0];
+        munit_logf(MUNIT_LOG_INFO, "  val='%s'", tuple->val);
         (void)LexExpect(tuple->val, tuple->type);
     }
 

--- a/test/parser.c
+++ b/test/parser.c
@@ -33,8 +33,8 @@ MunitResult CompareAST(const ms_AST *ast1, const ms_AST *ast2);
 MunitResult CompareExpressions(const ms_Expr *expr1, const ms_Expr *expr2);
 MunitResult CompareExpressionAtoms(ms_ExprAtomType type, const ms_ExprAtom *atom1, const ms_ExprAtom *atom2);
 MunitResult CompareByteCode(const ms_VMByteCode *bc1, const ms_VMByteCode *bc2);
-MunitResult CompareExpressionList(ms_ExprList *el1, ms_ExprList *el2);
-MunitResult CompareVMIdent(ms_VMIdent *id1, ms_VMIdent *id2);
+MunitResult CompareExpressionList(const ms_ExprList *el1, const ms_ExprList *el2);
+MunitResult CompareVMIdent(const ms_VMIdent *id1, const ms_VMIdent *id2);
 MunitResult CompareVMValues(const ms_VMValue *val1, const ms_VMValue *val2);
 MunitResult TestParseResultTuple(ParseResultTuple *tuples, size_t len);
 
@@ -1335,7 +1335,7 @@ MunitResult CompareByteCode(const ms_VMByteCode *bc1, const ms_VMByteCode *bc2) 
     return MUNIT_OK;
 }
 
-MunitResult CompareExpressionList(ms_ExprList *el1, ms_ExprList *el2) {
+MunitResult CompareExpressionList(const ms_ExprList *el1, const ms_ExprList *el2) {
     munit_assert_non_null(el1);
     munit_assert_non_null(el2);
 
@@ -1350,7 +1350,7 @@ MunitResult CompareExpressionList(ms_ExprList *el1, ms_ExprList *el2) {
     return MUNIT_OK;
 }
 
-MunitResult CompareVMIdent(ms_VMIdent *id1, ms_VMIdent *id2) {
+MunitResult CompareVMIdent(const ms_VMIdent *id1, const ms_VMIdent *id2) {
     munit_assert_non_null(id1);
     munit_assert_non_null(id1);
 

--- a/test/parser.h
+++ b/test/parser.h
@@ -28,6 +28,7 @@ MunitResult prs_TestParseLiterals(const MunitParameter params[], void *user_data
 MunitResult prs_TestParseUnaryExprs(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseBinaryExprs(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseExprPrecedence(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseFunctionCalls(const MunitParameter params[], void *user_data);
 
 /*
  * TEST DEFINITIONS
@@ -69,6 +70,14 @@ static MunitTest parser_tests[] = {
     {
         "/OperatorPrecedence",
         prs_TestParseExprPrecedence,
+        NULL,
+        NULL,
+        MUNIT_TEST_OPTION_NONE,
+        NULL
+    },
+    {
+        "/FunctionCalls",
+        prs_TestParseFunctionCalls,
         NULL,
         NULL,
         MUNIT_TEST_OPTION_NONE,

--- a/test/parser.h
+++ b/test/parser.h
@@ -27,6 +27,7 @@ MunitResult prs_TestParseErrors(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseLiterals(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseUnaryExprs(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseBinaryExprs(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseExprPrecedence(const MunitParameter params[], void *user_data);
 
 /*
  * TEST DEFINITIONS
@@ -60,6 +61,14 @@ static MunitTest parser_tests[] = {
     {
         "/BinaryExpressions",
         prs_TestParseBinaryExprs,
+        NULL,
+        NULL,
+        MUNIT_TEST_OPTION_NONE,
+        NULL
+    },
+    {
+        "/OperatorPrecedence",
+        prs_TestParseExprPrecedence,
         NULL,
         NULL,
         MUNIT_TEST_OPTION_NONE,


### PR DESCRIPTION
Rewrite the parser logic away from shunting yard and towards recursive descent to allow more flexibility in parsing logic; parser can now understand the '()' operator, which was much more challenging and fragile with recursive descent; other smaller changes include renaming things to be somewhat more clearly named; fix some errors that were preventing proper compilation on at least one Linux distro (Mint)