### PR TITLE
Implement statement parsing 

### DIFF
--- a/deps/libds/buffer.c
+++ b/deps/libds/buffer.c
@@ -99,7 +99,7 @@ DSBuffer *dsbuf_dup(const DSBuffer *str) {
 
     s->len = str->len;
     s->cap = str->cap;
-    s->str = malloc(s->cap);
+    s->str = calloc(s->cap, 1);
     if (!s->str) {
         goto cleanup_dsbuf_dup;
     }

--- a/src/lang.c
+++ b/src/lang.c
@@ -277,3 +277,34 @@ void ms_ExprDestroy(ms_Expr *expr) {
     }
     free(expr);
 }
+
+void ms_StmtDestroy(ms_Stmt *stmt) {
+    if (!stmt) { return; }
+
+    switch (stmt->type) {
+        case STMTTYPE_IF:
+            ms_ExprDestroy(stmt->cmpnt.ifstmt->expr);
+            stmt->cmpnt.ifstmt->expr = NULL;
+            dsarray_destroy(stmt->cmpnt.ifstmt->block);
+            stmt->cmpnt.ifstmt->block = NULL;
+            break;
+        case STMTTYPE_ASSIGNMENT:
+            dsbuf_destroy(stmt->cmpnt.assign->ident);
+            stmt->cmpnt.assign->ident = NULL;
+            ms_ExprDestroy(stmt->cmpnt.assign->expr);
+            stmt->cmpnt.assign->expr = NULL;
+            break;
+        case STMTTYPE_DECLARATION:
+            dsbuf_destroy(stmt->cmpnt.decl->ident);
+            stmt->cmpnt.decl->ident = NULL;
+            ms_ExprDestroy(stmt->cmpnt.decl->expr);
+            stmt->cmpnt.decl->expr = NULL;
+            break;
+        case STMTTYPE_EXPRESSION:
+            ms_ExprDestroy(stmt->cmpnt.expr);
+            stmt->cmpnt.expr = NULL;
+            break;
+    }
+
+    free(stmt);
+}

--- a/src/lang.c
+++ b/src/lang.c
@@ -401,6 +401,62 @@ ms_Expr *ms_ExprFlatten(ms_Expr *outer, ms_Expr *inner, ms_ExprLocation loc) {
     return outer;
 }
 
+bool ms_ExprIsIdent(const ms_Expr *expr) {
+    if (!expr) {
+        return false;
+    }
+
+    if (expr->type != EXPRTYPE_UNARY) {
+        return false;
+    }
+
+    if (!expr->cmpnt.u) {
+        return false;
+    }
+
+    if (expr->cmpnt.u->op != UNARY_NONE) {
+        return false;
+    }
+
+    if (expr->cmpnt.u->type != EXPRATOM_IDENT) {
+        return false;
+    }
+
+    return true;
+}
+
+bool ms_ExprIsQualifiedIdent(const ms_Expr *expr) {
+    if (!expr) {
+        return false;
+    }
+
+    if (expr->type == EXPRTYPE_UNARY) {
+        return ms_ExprIsIdent(expr);
+    }
+
+    if (!expr->cmpnt.b) {
+        return false;
+    }
+
+    if (expr->cmpnt.b->ltype == EXPRATOM_EXPRESSION) {
+        if (!ms_ExprIsQualifiedIdent(expr->cmpnt.b->latom.expr)) {
+            return false;
+        }
+    } else if (expr->cmpnt.b->ltype != EXPRATOM_IDENT) {
+        return false;
+    }
+
+    if (expr->cmpnt.b->rtype != EXPRATOM_IDENT) {
+        return false;
+    }
+
+    if (expr->cmpnt.b->op != BINARY_GETATTR) {
+        return false;
+    }
+
+    return true;
+}
+
 void ms_ValFuncDestroy(ms_ValFunc *fn) {
     if (!fn) { return; }
     dsbuf_destroy(fn->ident);

--- a/src/lang.c
+++ b/src/lang.c
@@ -471,6 +471,7 @@ void ms_ValFuncDestroy(ms_ValFunc *fn) {
 
 void ms_ExprDestroy(ms_Expr *expr) {
     if (!expr) { return; }
+
     switch (expr->type) {
         case EXPRTYPE_UNARY:
             if (expr->cmpnt.u) {
@@ -488,6 +489,7 @@ void ms_ExprDestroy(ms_Expr *expr) {
             }
             break;
     }
+
     free(expr);
 }
 
@@ -563,6 +565,9 @@ void ExprAtomDestroy(ms_ExprAtom *atom, ms_ExprAtomType type) {
             if (atom->val.type == MSVAL_FUNC) {
                 ms_ValFuncDestroy(atom->val.val.fn);
                 atom->val.val.fn = NULL;
+            } else if (atom->val.type == MSVAL_STR) {
+                dsbuf_destroy(atom->val.val.s);
+                atom->val.val.s = NULL;
             }
             break;
         case EXPRATOM_EMPTY:    /* no free required */
@@ -579,6 +584,7 @@ void StmtDeleteDestroy(ms_StmtDelete *del) {
 
 void StmtForDestroy(ms_StmtFor *forstmt) {
     if (!forstmt) { return; }
+
     switch (forstmt->type) {
         case FORSTMT_INCREMENT:
             if (forstmt->clause.inc) {
@@ -610,15 +616,20 @@ void StmtForDestroy(ms_StmtFor *forstmt) {
             }
             break;
     }
+
+    dsarray_destroy(forstmt->block);
+    forstmt->block = NULL;
     free(forstmt);
 }
 
 void StmtIfDestroy(ms_StmtIf *ifstmt) {
     if (!ifstmt) { return; }
+
     ms_ExprDestroy(ifstmt->expr);
     ifstmt->expr = NULL;
     dsarray_destroy(ifstmt->block);
     ifstmt->block = NULL;
+
     if (ifstmt->elif) {
         switch (ifstmt->elif->type) {
             case IFELSE_IF:
@@ -630,7 +641,9 @@ void StmtIfDestroy(ms_StmtIf *ifstmt) {
                 ifstmt->elif->clause.elstmt = NULL;
                 break;
         }
+        free(ifstmt->elif);
     }
+
     free(ifstmt);
 }
 

--- a/src/lang.c
+++ b/src/lang.c
@@ -664,5 +664,7 @@ void StmtDeclarationDestroy(ms_StmtDeclaration *decl) {
     decl->ident = NULL;
     ms_ExprDestroy(decl->expr);
     decl->expr = NULL;
+    StmtDeclarationDestroy(decl->next);
+    decl->next = NULL;
     free(decl);
 }

--- a/src/lang.c
+++ b/src/lang.c
@@ -25,6 +25,7 @@ void ExprAtomDestroy(ms_ExprAtom *atom, ms_ExprAtomType type);
 void StmtDeleteDestroy(ms_StmtDelete *del);
 void StmtForDestroy(ms_StmtFor *forstmt);
 void StmtIfDestroy(ms_StmtIf *ifstmt);
+void StmtImportDestroy(ms_StmtImport *import);
 void StmtElseDestroy(ms_StmtElse *elstmt);
 void StmtMergeDestroy(ms_StmtMerge *merge);
 void StmtReturnDestroy(ms_StmtReturn *ret);
@@ -510,6 +511,10 @@ void ms_StmtDestroy(ms_Stmt *stmt) {
             StmtIfDestroy(stmt->cmpnt.ifstmt);
             stmt->cmpnt.ifstmt = NULL;
             break;
+        case STMTTYPE_IMPORT:
+            StmtImportDestroy(stmt->cmpnt.import);
+            stmt->cmpnt.import = NULL;
+            break;
         case STMTTYPE_MERGE:
             StmtMergeDestroy(stmt->cmpnt.merge);
             stmt->cmpnt.merge = NULL;
@@ -585,6 +590,7 @@ void StmtForDestroy(ms_StmtFor *forstmt) {
                 forstmt->clause.inc->end = NULL;
                 ms_ExprDestroy(forstmt->clause.inc->step);
                 forstmt->clause.inc->step = NULL;
+                free(forstmt->clause.inc);
             }
             break;
         case FORSTMT_ITERATOR:
@@ -593,12 +599,14 @@ void StmtForDestroy(ms_StmtFor *forstmt) {
                 forstmt->clause.iter->ident = NULL;
                 ms_ExprDestroy(forstmt->clause.iter->iter);
                 forstmt->clause.iter->iter = NULL;
+                free(forstmt->clause.iter);
             }
             break;
         case FORSTMT_EXPR:
             if (forstmt->clause.expr) {
                 ms_ExprDestroy(forstmt->clause.expr->expr);
                 forstmt->clause.expr->expr = NULL;
+                free(forstmt->clause.expr);
             }
             break;
     }
@@ -624,6 +632,15 @@ void StmtIfDestroy(ms_StmtIf *ifstmt) {
         }
     }
     free(ifstmt);
+}
+
+void StmtImportDestroy(ms_StmtImport *import) {
+    if (!import) { return; }
+    ms_ExprDestroy(import->ident);
+    import->ident = NULL;
+    dsbuf_destroy(import->alias);
+    import->alias = NULL;
+    free(import);
 }
 
 void StmtElseDestroy(ms_StmtElse *elstmt) {

--- a/src/lang.c
+++ b/src/lang.c
@@ -282,14 +282,22 @@ void ms_StmtDestroy(ms_Stmt *stmt) {
     if (!stmt) { return; }
 
     switch (stmt->type) {
+        case STMTTYPE_EMPTY:        // Fall through
+        case STMTTYPE_BREAK:        // Fall through
+        case STMTTYPE_CONTINUE:
+            break;
         case STMTTYPE_IF:
             ms_ExprDestroy(stmt->cmpnt.ifstmt->expr);
             stmt->cmpnt.ifstmt->expr = NULL;
             dsarray_destroy(stmt->cmpnt.ifstmt->block);
             stmt->cmpnt.ifstmt->block = NULL;
             break;
+        case STMTTYPE_RETURN:
+            ms_ExprDestroy(stmt->cmpnt.ret->expr);
+            stmt->cmpnt.ret->expr = NULL;
+            break;
         case STMTTYPE_ASSIGNMENT:
-            dsbuf_destroy(stmt->cmpnt.assign->ident);
+            ms_ExprDestroy(stmt->cmpnt.assign->ident);
             stmt->cmpnt.assign->ident = NULL;
             ms_ExprDestroy(stmt->cmpnt.assign->expr);
             stmt->cmpnt.assign->expr = NULL;

--- a/src/lang.h
+++ b/src/lang.h
@@ -155,10 +155,37 @@ typedef enum {
 
 typedef DSArray ms_StmtBlock;
 
+typedef struct ms_StmtIf ms_StmtIf;
+typedef struct ms_StmtElse ms_StmtElse;
+
+typedef union {
+    ms_StmtIf *ifstmt;
+    ms_StmtElse *elstmt;
+} ms_StmtIfElseClause;
+
+typedef enum {
+    IFELSE_IF,
+    IFELSE_ELSE,
+} ms_StmtIfElseType;
+
 typedef struct {
+    ms_StmtIfElseClause clause;
+    ms_StmtIfElseType type;
+} ms_StmtIfElse;
+
+struct ms_StmtIf {
     ms_Expr *expr;
     ms_StmtBlock *block;
-} ms_StmtIf;
+    ms_StmtIfElse *elif;
+};
+
+struct ms_StmtElse {
+    ms_StmtBlock *block;
+};
+
+typedef struct {
+    ms_Expr *expr;
+} ms_StmtReturn;
 
 typedef struct {
     ms_Ident *ident;
@@ -172,6 +199,7 @@ typedef struct {
 
 typedef enum {
     STMTTYPE_IF,
+    STMTTYPE_RETURN,
     STMTTYPE_ASSIGNMENT,
     STMTTYPE_DECLARATION,
     STMTTYPE_EXPRESSION,
@@ -179,6 +207,7 @@ typedef enum {
 
 typedef union {
     ms_StmtIf *ifstmt;
+    ms_StmtReturn *ret;
     ms_StmtAssignment *assign;
     ms_StmtDeclaration *decl;
     ms_Expr *expr;

--- a/src/lang.h
+++ b/src/lang.h
@@ -236,6 +236,11 @@ typedef struct {
 } ms_StmtDelete;
 
 typedef struct {
+    ms_Expr *ident;
+    ms_Ident *alias;
+} ms_StmtImport;
+
+typedef struct {
     ms_Expr *left;
     ms_Expr *right;
 } ms_StmtMerge;
@@ -261,6 +266,7 @@ typedef enum {
     STMTTYPE_DELETE,
     STMTTYPE_FOR,
     STMTTYPE_IF,
+    STMTTYPE_IMPORT,
     STMTTYPE_MERGE,
     STMTTYPE_RETURN,
     STMTTYPE_ASSIGNMENT,
@@ -274,6 +280,7 @@ typedef union {
     ms_StmtDelete *del;
     ms_StmtFor *forstmt;
     ms_StmtIf *ifstmt;
+    ms_StmtImport *import;
     ms_StmtMerge *merge;
     ms_StmtReturn *ret;
     ms_StmtAssignment *assign;

--- a/src/lang.h
+++ b/src/lang.h
@@ -354,6 +354,17 @@ ms_Expr *ms_ExprDup(const ms_Expr *src);
 ms_Expr *ms_ExprFlatten(ms_Expr *outer, ms_Expr *inner, ms_ExprLocation loc);
 
 /**
+* @brief Determine if an expression contains _only_ a single identifier.
+*/
+bool ms_ExprIsIdent(const ms_Expr *expr);
+
+/**
+* @brief Determine if an expression contains _only_ a qualified identifier.
+* Qualified identifiers are in the form: IDENTIFIER ('.' IDENTIFIER)*
+*/
+bool ms_ExprIsQualifiedIdent(const ms_Expr *expr);
+
+/**
 * @brief Destroy the given @c ms_ValFunc and any nested arguments and statements.
 */
 void ms_ValFuncDestroy(ms_ValFunc *fn);

--- a/src/lang.h
+++ b/src/lang.h
@@ -21,33 +21,25 @@
 #include "libds/buffer.h"
 #include "lexer.h"
 
-/**
-* @brief Expression syntax tree object
-*/
 typedef struct ms_Expr ms_Expr;
 
-/**
-* @brief Identifier
-*/
-typedef DSBuffer ms_Ident;
+/*
+ * MISCELLANEOUS LANGUAGE COMPONENTS
+ */
 
-/**
-* @brief Expression list object
-*/
+typedef DSBuffer ms_Ident;
 typedef DSArray ms_ExprList;
 
 /*
-* @brief Typedefs of mscript values
-*/
+ * VALUE LANGUAGE COMPONENTS
+ */
+
 typedef double ms_ValFloat;
 typedef long long ms_ValInt;
 typedef DSBuffer ms_ValStr;
 typedef bool ms_ValBool;
 typedef const void ms_ValNull;
 
-/**
-* @brief Enumeration of data value types in mscript
-*/
 typedef enum {
     MSVAL_FLOAT,
     MSVAL_INT,
@@ -56,9 +48,6 @@ typedef enum {
     MSVAL_NULL,
 } ms_ValDataType;
 
-/**
-* @brief Union of data types in mscript
-*/
 typedef union {
     ms_ValFloat f;
     ms_ValInt i;
@@ -67,17 +56,15 @@ typedef union {
     ms_ValNull *n;
 } ms_ValData;
 
-/**
-* @brief Structure of any value within mscript
-*/
 typedef struct {
     ms_ValDataType type;
     ms_ValData val;
 } ms_Value;
 
-/**
-* @brief Expression atom union
-*/
+/*
+ * EXPRESSION LANGUAGE COMPONENTS
+ */
+
 typedef union {
     ms_Expr *expr;
     ms_Value val;
@@ -85,9 +72,6 @@ typedef union {
     ms_ExprList *list;
 } ms_ExprAtom;
 
-/**
-* @brief Type of expression atom
-*/
 typedef enum {
     EXPRATOM_EMPTY,
     EXPRATOM_EXPRESSION,
@@ -96,9 +80,6 @@ typedef enum {
     EXPRATOM_EXPRLIST,
 } ms_ExprAtomType;
 
-/**
-* @brief Type of operation for this binary expression
-*/
 typedef enum {
     UNARY_NONE,
     UNARY_MINUS,
@@ -106,18 +87,12 @@ typedef enum {
     UNARY_BITWISE_NOT,
 } ms_ExprUnaryOp;
 
-/*
-* @brief Unary expression object
-*/
 typedef struct {
     ms_ExprAtom atom;
     ms_ExprAtomType type;
     ms_ExprUnaryOp op;
 } ms_ExprUnary;
 
-/**
-* @brief Type of operation for this binary expression
-*/
 typedef enum {
     BINARY_EMPTY,
     BINARY_PLUS,
@@ -143,9 +118,6 @@ typedef enum {
     BINARY_CALL,
 } ms_ExprBinaryOp;
 
-/**
-* @brief Binary expression object
-*/
 typedef struct {
     ms_ExprAtom latom;
     ms_ExprAtomType ltype;
@@ -154,44 +126,74 @@ typedef struct {
     ms_ExprAtomType rtype;
 } ms_ExprBinary;
 
-/*
-* @brief Union of binary or unary expression
-*/
 typedef union {
     ms_ExprBinary *b;
     ms_ExprUnary *u;
 } ms_ExprComponent;
 
-/*
-* @brief Type of expression (binary or unary)
-*/
 typedef enum {
     EXPRTYPE_BINARY,
     EXPRTYPE_UNARY
 } ms_ExprType;
 
-/**
-* @brief Expression object
-*/
 struct ms_Expr {
     ms_ExprComponent cmpnt;
     ms_ExprType type;
 };
 
-/**
-* @brief Enumeration used to indicate which part of an expression to flatten
-* into the outer/containing expression.
-*/
+/* Enumeration used to indicate which part of an expression to flatten
+ * into the outer/containing expression. */
 typedef enum {
     EXPRLOC_UNARY,
     EXPRLOC_LEFT,
     EXPRLOC_RIGHT,
 } ms_ExprLocation;
 
-/**
-* @brief Placeholder for a more sophisticated AST object.
-*/
-typedef ms_Expr ms_AST;
+/*
+ * STATEMENT LANGUAGE COMPONENTS
+ */
+
+typedef DSArray ms_StmtBlock;
+
+typedef struct {
+    ms_Expr *expr;
+    ms_StmtBlock *block;
+} ms_StmtIf;
+
+typedef struct {
+    ms_Ident *ident;
+    ms_Expr *expr;
+} ms_StmtAssignment;
+
+typedef struct {
+    ms_Ident *ident;
+    ms_Expr *expr;
+} ms_StmtDeclaration;
+
+typedef enum {
+    STMTTYPE_IF,
+    STMTTYPE_ASSIGNMENT,
+    STMTTYPE_DECLARATION,
+    STMTTYPE_EXPRESSION,
+} ms_StmtType;
+
+typedef union {
+    ms_StmtIf *ifstmt;
+    ms_StmtAssignment *assign;
+    ms_StmtDeclaration *decl;
+    ms_Expr *expr;
+} ms_StmtComponent;
+
+typedef struct {
+    ms_StmtComponent cmpnt;
+    ms_StmtType type;
+} ms_Stmt;
+
+/*
+ * ABSTRACT SYNTAX TREE ROOT
+ */
+
+typedef ms_Stmt ms_AST;
 
 /**
 * @brief Create a new @c ms_Expr object.
@@ -247,9 +249,14 @@ ms_Expr *ms_ExprFlatten(ms_Expr *outer, ms_Expr *inner, ms_ExprLocation loc);
 */
 void ms_ExprDestroy(ms_Expr *expr);
 
+/**
+* @brief Destroy the given @c ms_Stmt and nested AST elements.
+*/
+void ms_StmtDestroy(ms_Stmt *stmt);
+
 /*
 * @brief Placeholder for real AST destroy function.
 */
-#define ms_ASTDestroy(ast) ms_ExprDestroy(ast)
+#define ms_ASTDestroy(ast) ms_StmtDestroy(ast)
 
 #endif //MSCRIPT_LANG_H

--- a/src/lang.h
+++ b/src/lang.h
@@ -27,8 +27,10 @@ typedef struct ms_Expr ms_Expr;
  * MISCELLANEOUS LANGUAGE COMPONENTS
  */
 
+typedef DSArray ms_StmtBlock;
 typedef DSBuffer ms_Ident;
 typedef DSArray ms_ExprList;
+typedef DSArray ms_ArgList;
 
 /*
  * VALUE LANGUAGE COMPONENTS
@@ -40,12 +42,19 @@ typedef DSBuffer ms_ValStr;
 typedef bool ms_ValBool;
 typedef const void ms_ValNull;
 
+typedef struct {
+    ms_Ident *ident;
+    ms_ArgList *args;
+    ms_StmtBlock *block;
+} ms_ValFunc;
+
 typedef enum {
     MSVAL_FLOAT,
     MSVAL_INT,
     MSVAL_STR,
     MSVAL_BOOL,
     MSVAL_NULL,
+    MSVAL_FUNC,
 } ms_ValDataType;
 
 typedef union {
@@ -54,6 +63,7 @@ typedef union {
     ms_ValStr *s;
     ms_ValBool b;
     ms_ValNull *n;
+    ms_ValFunc *fn;
 } ms_ValData;
 
 typedef struct {
@@ -153,8 +163,6 @@ typedef enum {
 /*
  * STATEMENT LANGUAGE COMPONENTS
  */
-
-typedef DSArray ms_StmtBlock;
 
 typedef struct ms_StmtBreak ms_StmtBreak;           /* dummy types required to be declared */
 typedef struct ms_StmtContinue ms_StmtContinue;     /* as pointers (which will have to be NULL) */
@@ -305,6 +313,11 @@ ms_Expr *ms_ExprNewWithIdent(const char *name, size_t len);
 ms_Expr *ms_ExprNewWithList(ms_ExprList *list);
 
 /**
+* @brief Create a new @c ms_Expr object for containing a function expression.
+*/
+ms_Expr *ms_ExprNewWithFunc(ms_ValFunc *fn);
+
+/**
 * @brief Create a new unary @c ms_Expr object containing a floating point
 * number from a string.
 */
@@ -337,6 +350,11 @@ ms_Expr *ms_ExprDup(const ms_Expr *src);
 * @returns the outer expression
 */
 ms_Expr *ms_ExprFlatten(ms_Expr *outer, ms_Expr *inner, ms_ExprLocation loc);
+
+/**
+* @brief Destroy the given @c ms_ValFunc and any nested arguments and statements.
+*/
+void ms_ValFuncDestroy(ms_ValFunc *fn);
 
 /**
 * @brief Destroy the given @c ms_Expr and any nested expressions.

--- a/src/lang.h
+++ b/src/lang.h
@@ -254,10 +254,12 @@ typedef struct {
     ms_Expr *expr;
 } ms_StmtAssignment;
 
-typedef struct {
+typedef struct ms_StmtDeclaration ms_StmtDeclaration;
+struct ms_StmtDeclaration{
     ms_Ident *ident;
     ms_Expr *expr;
-} ms_StmtDeclaration;
+    ms_StmtDeclaration *next;
+};
 
 typedef enum {
     STMTTYPE_EMPTY,

--- a/src/lang.h
+++ b/src/lang.h
@@ -278,6 +278,11 @@ ms_Expr *ms_ExprFloatFromString(const char *str);
 ms_Expr *ms_ExprIntFromString(const char *str);
 
 /**
+* @brief Duplicate the given expression.
+*/
+ms_Expr *ms_ExprDup(const ms_Expr *src);
+
+/**
 * @brief Flatten two expressions such that the expression tree does not
 * become too deep too quickly.
 *

--- a/src/lang.h
+++ b/src/lang.h
@@ -188,6 +188,15 @@ struct ms_StmtElse {
 
 typedef struct {
     ms_Expr *expr;
+} ms_StmtDelete;
+
+typedef struct {
+    ms_Expr *left;
+    ms_Expr *right;
+} ms_StmtMerge;
+
+typedef struct {
+    ms_Expr *expr;
 } ms_StmtReturn;
 
 typedef struct {
@@ -204,7 +213,9 @@ typedef enum {
     STMTTYPE_EMPTY,
     STMTTYPE_BREAK,
     STMTTYPE_CONTINUE,
+    STMTTYPE_DELETE,
     STMTTYPE_IF,
+    STMTTYPE_MERGE,
     STMTTYPE_RETURN,
     STMTTYPE_ASSIGNMENT,
     STMTTYPE_DECLARATION,
@@ -214,7 +225,9 @@ typedef enum {
 typedef union {
     ms_StmtBreak *brk;
     ms_StmtContinue *cont;
+    ms_StmtDelete *del;
     ms_StmtIf *ifstmt;
+    ms_StmtMerge *merge;
     ms_StmtReturn *ret;
     ms_StmtAssignment *assign;
     ms_StmtDeclaration *decl;

--- a/src/lang.h
+++ b/src/lang.h
@@ -116,6 +116,7 @@ typedef enum {
     BINARY_AND,
     BINARY_OR,
     BINARY_CALL,
+    BINARY_GETATTR,
 } ms_ExprBinaryOp;
 
 typedef struct {
@@ -190,7 +191,7 @@ typedef struct {
 } ms_StmtReturn;
 
 typedef struct {
-    ms_Ident *ident;
+    ms_Expr *ident;
     ms_Expr *expr;
 } ms_StmtAssignment;
 
@@ -200,6 +201,7 @@ typedef struct {
 } ms_StmtDeclaration;
 
 typedef enum {
+    STMTTYPE_EMPTY,
     STMTTYPE_BREAK,
     STMTTYPE_CONTINUE,
     STMTTYPE_IF,

--- a/src/lang.h
+++ b/src/lang.h
@@ -286,11 +286,13 @@ typedef struct {
     ms_StmtType type;
 } ms_Stmt;
 
+typedef DSArray ms_Module;
+
 /*
  * ABSTRACT SYNTAX TREE ROOT
  */
 
-typedef ms_Stmt ms_AST;
+typedef ms_Module ms_AST;
 
 /**
 * @brief Create a new @c ms_Expr object.
@@ -369,6 +371,6 @@ void ms_StmtDestroy(ms_Stmt *stmt);
 /*
 * @brief Placeholder for real AST destroy function.
 */
-#define ms_ASTDestroy(ast) ms_StmtDestroy(ast)
+#define ms_ASTDestroy(ast) dsarray_destroy(ast)
 
 #endif //MSCRIPT_LANG_H

--- a/src/lang.h
+++ b/src/lang.h
@@ -155,6 +155,8 @@ typedef enum {
 
 typedef DSArray ms_StmtBlock;
 
+typedef struct ms_StmtBreak ms_StmtBreak;           /* dummy types required to be declared */
+typedef struct ms_StmtContinue ms_StmtContinue;     /* as pointers (which will have to be NULL) */
 typedef struct ms_StmtIf ms_StmtIf;
 typedef struct ms_StmtElse ms_StmtElse;
 
@@ -198,6 +200,8 @@ typedef struct {
 } ms_StmtDeclaration;
 
 typedef enum {
+    STMTTYPE_BREAK,
+    STMTTYPE_CONTINUE,
     STMTTYPE_IF,
     STMTTYPE_RETURN,
     STMTTYPE_ASSIGNMENT,
@@ -206,6 +210,8 @@ typedef enum {
 } ms_StmtType;
 
 typedef union {
+    ms_StmtBreak *brk;
+    ms_StmtContinue *cont;
     ms_StmtIf *ifstmt;
     ms_StmtReturn *ret;
     ms_StmtAssignment *assign;

--- a/src/lang.h
+++ b/src/lang.h
@@ -158,6 +158,43 @@ typedef DSArray ms_StmtBlock;
 
 typedef struct ms_StmtBreak ms_StmtBreak;           /* dummy types required to be declared */
 typedef struct ms_StmtContinue ms_StmtContinue;     /* as pointers (which will have to be NULL) */
+
+typedef enum {
+    FORSTMT_INCREMENT,
+    FORSTMT_ITERATOR,
+    FORSTMT_EXPR,
+} ms_StmtForType;
+
+typedef struct {
+    ms_Expr *ident;
+    ms_Expr *init;
+    ms_Expr *end;
+    ms_Expr *step;
+    bool declare;
+} ms_StmtForIncrement;
+
+typedef struct {
+    ms_Expr *ident;
+    ms_Expr *iter;
+    bool declare;
+} ms_StmtForIterator;
+
+typedef struct {
+    ms_Expr *expr;
+} ms_StmtForExpr;
+
+typedef union {
+    ms_StmtForIncrement *inc;
+    ms_StmtForIterator *iter;
+    ms_StmtForExpr *expr;
+} ms_StmtForClause;
+
+typedef struct {
+    ms_StmtForClause clause;
+    ms_StmtForType type;
+    ms_StmtBlock *block;
+} ms_StmtFor;
+
 typedef struct ms_StmtIf ms_StmtIf;
 typedef struct ms_StmtElse ms_StmtElse;
 
@@ -214,6 +251,7 @@ typedef enum {
     STMTTYPE_BREAK,
     STMTTYPE_CONTINUE,
     STMTTYPE_DELETE,
+    STMTTYPE_FOR,
     STMTTYPE_IF,
     STMTTYPE_MERGE,
     STMTTYPE_RETURN,
@@ -226,6 +264,7 @@ typedef union {
     ms_StmtBreak *brk;
     ms_StmtContinue *cont;
     ms_StmtDelete *del;
+    ms_StmtFor *forstmt;
     ms_StmtIf *ifstmt;
     ms_StmtMerge *merge;
     ms_StmtReturn *ret;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -59,6 +59,7 @@ static KeywordTuple KEYWORDS[] = {
     { "while", RESERVED_KW }, { "except", RESERVED_KW }, { "num", RESERVED_KW },
     { "str", RESERVED_KW }, { "bool", RESERVED_KW }, { "datetime", RESERVED_KW },
     { "obj", RESERVED_KW }, { "as", RESERVED_KW }, { "package", RESERVED_KW },
+    { "with", RESERVED_KW }, { "using", RESERVED_KW }
 };
 
 /*
@@ -578,7 +579,7 @@ static ms_Token *LexerLexNumber(ms_Lexer *lex, int prev) {
     }
 
     // Accept basic digits
-    ms_TokenType type = INT_NUMBER;
+    ms_TokenType type = (prev == '.') ? FLOAT_NUMBER : INT_NUMBER;
     LexerAcceptRun(lex, BASE_10_DIGITS);
 
     // Accept standard decimal digits

--- a/src/parser.c
+++ b/src/parser.c
@@ -236,7 +236,7 @@ void ms_ParserDestroy(ms_Parser *prs) {
  * Expression Grammar:
  *
  * stmt:            'break' | 'continue' | del_stmt | for_stmt | if_stmt |
- *                  merge_stmt | ret_stmt | declare | assign | expr
+ *                  merge_stmt | ret_stmt | func_decl | declare | assign | expr
  * for_stmt:        'for' ('var') expr ':=' expr (':' expr (':' expr)) |
  *                  'for' ('var') expr 'in' expr block |
  *                  'for' expr block

--- a/src/parser.c
+++ b/src/parser.c
@@ -428,7 +428,7 @@ static ms_ParseResult ParserParseBlock(ms_Parser *prs, ms_StmtBlock **block) {
             return PARSE_ERROR;
         }
         if (ParserExpectToken(prs, RBRACE)) {
-            ms_StmtDestroy(stmt);
+            dsarray_append(*block, stmt);
             break;
         }
         if (!ParserExpectTokenIfNotEOF(prs, NEWLINE_TOK)) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -223,7 +223,8 @@ void ms_ParserDestroy(ms_Parser *prs) {
 /*
  * Expression Grammar:
  *
- * stmt:            if_stmt | declare | ret_stmt | assign | expr
+ * stmt:            'break' | 'continue' | if_stmt | declare | ret_stmt |
+ *                  assign | expr
  * if_stmt:         'if' expr block [else_stmt]
  * else_stmt:       'else' if_stmt | 'else' block
  * ret_stmt:        'return' expr
@@ -271,6 +272,16 @@ static ms_ParseResult ParserParseStatement(ms_Parser *prs, ms_Stmt **stmt) {
     }
 
     switch (cur->type) {
+        case KW_BREAK:
+            (*stmt)->type = STMTTYPE_BREAK;
+            (*stmt)->cmpnt.brk = NULL;
+            ParserConsumeToken(prs);
+            break;
+        case KW_CONTINUE:
+            (*stmt)->type = STMTTYPE_CONTINUE;
+            (*stmt)->cmpnt.cont = NULL;
+            ParserConsumeToken(prs);
+            break;
         case KW_IF:
             (*stmt)->type = STMTTYPE_IF;
             if ((res = ParserParseIfStatement(prs, &(*stmt)->cmpnt.ifstmt)) == PARSE_ERROR) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -623,7 +623,7 @@ static ms_ParseResult ParserParseIfStatement(ms_Parser *prs, ms_StmtIf **ifstmt)
     }
 
     if (!ParserExpectToken(prs, KW_ELSE)) {
-        return PARSE_ERROR;
+        return PARSE_SUCCESS;
     }
 
     return ParserParseElseStatement(prs, &(*ifstmt)->elif);

--- a/src/parser.c
+++ b/src/parser.c
@@ -237,16 +237,17 @@ void ms_ParserDestroy(ms_Parser *prs) {
  *
  * stmt:            'break' | 'continue' | del_stmt | for_stmt | if_stmt |
  *                  merge_stmt | ret_stmt | declare | assign | expr
- * for_stmt:        'for' ['var'] expr ':=' expr [':' expr [':' expr]] |
- *                  'for' ['var'] expr 'in' expr block |
+ * for_stmt:        'for' ('var') expr ':=' expr (':' expr (':' expr)) |
+ *                  'for' ('var') expr 'in' expr block |
  *                  'for' expr block
- * if_stmt:         'if' expr block [else_stmt]
+ * if_stmt:         'if' expr block (else_stmt)
  * else_stmt:       'else' if_stmt | 'else' block
  * del_stmt:        'delete' expr
  * merge_stmt:      'merge' expr ':=' expr
  * ret_stmt:        'return' expr
  * block:           '{' stmt* '}'
- * declare:         'var' IDENTIFIER [':=' expr] (',' IDENTIFIER [':=' expr])*
+ * func_decl:       'func' IDENTIFIER '(' ident_list ')' block
+ * declare:         'var' IDENTIFIER (':=' expr) (',' IDENTIFIER (':=' expr))*
  * assign:          expr (':=' | '+=' | '-=' | '*=' | '/=' | '\=' | '%=') expr
  *
  * expr:            or_expr ('||' or_expr)*
@@ -262,13 +263,15 @@ void ms_ParserDestroy(ms_Parser *prs) {
  * power_expr:      atom_expr ('**' arith_expr)*
  * term_expr:       ('-'|'!'|'~') atom_expr | power_expr
  * atom_expr:       atom [accessor]*
- * atom:            NUMBER | STRING | KW_TRUE | KW_FALSE | KW_NULL |
- *                  IDENTIFIER | BUILTIN_FUNC | GLOBAL | expr | '(' expr ')'
+ * atom:            NUMBER | STRING | KW_TRUE | KW_FALSE | KW_NULL | GLOBAL |
+ *                  IDENTIFIER | BUILTIN_FUNC | func_expr | expr | '(' expr ')'
+ * func_expr:       'func' (IDENTIFIER) '(' ident_list ')' block
  *
  * accessor:        arg_list | sub_list | '.' IDENTIFIER
- * expr_list:       expr [',' expr]*
+ * expr_list:       (expr (',' expr)*)
  * arg_list:        '(' expr_list ')'
  * sub_list:        '[' expr_list ']'
+ * ident_list:      (IDENTIFIER (',' IDENTIFIER)*)
  */
 
 /*

--- a/src/parser.c
+++ b/src/parser.c
@@ -421,6 +421,9 @@ static ms_ParseResult ParserParseBlock(ms_Parser *prs, ms_StmtBlock **block) {
         if (ParserParseStatement(prs, &stmt) == PARSE_ERROR) {
             return PARSE_ERROR;
         }
+        if (ParserExpectToken(prs, RBRACE)) {
+            break;
+        }
         if (!ParserExpectTokenIfNotEOF(prs, NEWLINE_TOK)) {
             ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, TOK_NEWLINE, prs->line, prs->col);
             return PARSE_ERROR;

--- a/src/parser.c
+++ b/src/parser.c
@@ -254,7 +254,7 @@ void ms_ParserDestroy(ms_Parser *prs) {
  * del_stmt:        'delete' expr
  * import_stmt:     'import' expr (':' IDENTIFIER)
  * merge_stmt:      'merge' expr ':=' expr
- * ret_stmt:        'return' expr
+ * ret_stmt:        'return' (expr)
  * block:           '{' stmt* '}'
  * func_decl:       'func' IDENTIFIER '(' ident_list ')' block
  * declare:         'var' IDENTIFIER (':=' expr) (',' IDENTIFIER (':=' expr))*
@@ -737,6 +737,20 @@ static ms_ParseResult ParserParseReturnStatement(ms_Parser *prs, ms_StmtReturn *
     }
 
     ParserConsumeToken(prs);
+
+    if (!prs->cur || ParserExpectToken(prs, NEWLINE_TOK) || ParserExpectToken(prs, RBRACE)) {
+        ms_ValData p;
+        p.n = MS_VM_NULL_POINTER;
+        (*ret)->expr = ms_ExprNewWithVal(MSVAL_NULL, p);
+        if (!(*ret)->expr) {
+            ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
+            return PARSE_ERROR;
+        }
+
+        ParserConsumeToken(prs);
+        return PARSE_SUCCESS;
+    }
+
     return ParserParseExpression(prs, &(*ret)->expr);
 }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -26,6 +26,7 @@
 #include "libds/hash.h"
 #include "obj.h"
 #include "vm.h"
+#include "lang.h"
 
 #define FRAME_DATA_STACK_LIMIT_L (256)
 #define VM_FRAME_STACK_LIMIT_L (256)
@@ -606,6 +607,9 @@ static inline size_t VMPrint(ms_VM *vm) {
             break;
         case MSVAL_STR:
             printf("%s\n", dsbuf_char_ptr(v->val.s));
+            break;
+        case MSVAL_FUNC:
+            printf("%s\n", dsbuf_char_ptr(v->val.fn->ident));
             break;
     }
     return 1;

--- a/test/lexer.c
+++ b/test/lexer.c
@@ -39,7 +39,8 @@ static MunitParameterEnum int_num_params[] = {
 
 static char* float_num_vals[] = {
     "32223.53", "3.14", "2.7182818284", "1.6180339", "1.414", "2.",
-    "2402.", "1332.", "10e4", "1e10", "2.3e8", "8.e4", "7e33",
+    "2402.", "1332.", "10e4", "1e10", "2.3e8", "8.e4", "7e33", ".2",
+    ".0314", "0.02718",
     NULL
 };
 
@@ -83,7 +84,7 @@ static char *reserved_keyword_vals[] = {
     "while", "switch", "goto", "error", "class", "private", "public",
     "protected", "yield", "from", "try", "except", "finally", "do", "and",
     "or", "mut", "const", "async", "await", "repeat", "until", "package",
-    "num", "str", "bool", "datetime", "obj", "as",
+    "num", "str", "bool", "datetime", "obj", "as", "with", "using",
     NULL
 };
 

--- a/test/parser.c
+++ b/test/parser.c
@@ -176,6 +176,7 @@ static MunitResult CompareArgumentList(const ms_ArgList *al1, const ms_ArgList *
 static MunitResult CompareBlocks(const ms_StmtBlock *blk1, const ms_StmtBlock *blk2);
 static MunitResult CompareForStatement(const ms_StmtFor *for1, const ms_StmtFor *for2);
 static MunitResult CompareIfElseStatement(const ms_StmtIfElse *elif1, const ms_StmtIfElse *elif2);
+static MunitResult CompareDeclarations(const ms_StmtDeclaration *decl1, const ms_StmtDeclaration *decl2);
 static MunitResult CompareExpressions(const ms_Expr *expr1, const ms_Expr *expr2);
 static MunitResult CompareExpressionAtoms(ms_ExprAtomType type, const ms_ExprAtom *atom1, const ms_ExprAtom *atom2);
 static MunitResult CompareByteCode(const ms_VMByteCode *bc1, const ms_VMByteCode *bc2);
@@ -1684,8 +1685,7 @@ static MunitResult CompareStatements(const ms_Stmt *stmt1, const ms_Stmt *stmt2)
             CompareExpressions(stmt1->cmpnt.ret->expr, stmt2->cmpnt.ret->expr);
             break;
         case STMTTYPE_DECLARATION:
-            CompareIdent(stmt1->cmpnt.decl->ident, stmt2->cmpnt.decl->ident);
-            CompareExpressions(stmt1->cmpnt.decl->expr, stmt2->cmpnt.decl->expr);
+            CompareDeclarations(stmt1->cmpnt.decl, stmt2->cmpnt.decl);
             break;
         case STMTTYPE_ASSIGNMENT:
             CompareExpressions(stmt1->cmpnt.assign->ident, stmt2->cmpnt.assign->ident);
@@ -1770,11 +1770,26 @@ static MunitResult CompareIfElseStatement(const ms_StmtIfElse *elif1, const ms_S
         case IFELSE_IF:
             CompareExpressions(elif1->clause.ifstmt->expr, elif2->clause.ifstmt->expr);
             CompareBlocks(elif1->clause.ifstmt->block, elif2->clause.ifstmt->block);
-            CompareIfElseStatement(elif1->clause.ifstmt->elif, elif2->clause.ifstmt->elif);
+            if ((elif1->clause.ifstmt->elif) || (elif2->clause.ifstmt->elif)) {
+                CompareIfElseStatement(elif1->clause.ifstmt->elif, elif2->clause.ifstmt->elif);
+            }
             break;
         case IFELSE_ELSE:
             CompareBlocks(elif1->clause.elstmt->block, elif2->clause.elstmt->block);
             break;
+    }
+
+    return MUNIT_OK;
+}
+
+static MunitResult CompareDeclarations(const ms_StmtDeclaration *decl1, const ms_StmtDeclaration *decl2) {
+    munit_assert_non_null(decl1);
+    munit_assert_non_null(decl2);
+
+    CompareIdent(decl1->ident, decl2->ident);
+    CompareExpressions(decl1->expr, decl2->expr);
+    if ((decl1->next) || (decl2->next)) {
+        CompareDeclarations(decl1->next, decl2->next);
     }
 
     return MUNIT_OK;

--- a/test/parser.h
+++ b/test/parser.h
@@ -34,6 +34,7 @@ MunitResult prs_TestParseImportStatement(const MunitParameter params[], void *us
 MunitResult prs_TestParseMergeStatement(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseReturnStatement(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseDeclaration(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseAssignment(const MunitParameter params[], void *user_data);
 
 /*
  * TEST DEFINITIONS

--- a/test/parser.h
+++ b/test/parser.h
@@ -29,6 +29,8 @@ MunitResult prs_TestParseUnaryExprs(const MunitParameter params[], void *user_da
 MunitResult prs_TestParseBinaryExprs(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseExprPrecedence(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseFunctionCalls(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseDeleteStatement(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseImportStatement(const MunitParameter params[], void *user_data);
 
 /*
  * TEST DEFINITIONS

--- a/test/parser.h
+++ b/test/parser.h
@@ -30,6 +30,9 @@ MunitResult prs_TestParseBinaryExprs(const MunitParameter params[], void *user_d
 MunitResult prs_TestParseExprPrecedence(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseFunctionCalls(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseDeleteStatement(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseForIncStatements(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseForIterStatements(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseForExprStatements(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseIfStatements(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseImportStatement(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseMergeStatement(const MunitParameter params[], void *user_data);

--- a/test/parser.h
+++ b/test/parser.h
@@ -37,6 +37,7 @@ MunitResult prs_TestParseIfStatements(const MunitParameter params[], void *user_
 MunitResult prs_TestParseImportStatement(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseMergeStatement(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseReturnStatement(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseFuncDeclaration(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseDeclaration(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseAssignment(const MunitParameter params[], void *user_data);
 

--- a/test/parser.h
+++ b/test/parser.h
@@ -31,6 +31,9 @@ MunitResult prs_TestParseExprPrecedence(const MunitParameter params[], void *use
 MunitResult prs_TestParseFunctionCalls(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseDeleteStatement(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseImportStatement(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseMergeStatement(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseReturnStatement(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseDeclaration(const MunitParameter params[], void *user_data);
 
 /*
  * TEST DEFINITIONS

--- a/test/parser.h
+++ b/test/parser.h
@@ -30,6 +30,7 @@ MunitResult prs_TestParseBinaryExprs(const MunitParameter params[], void *user_d
 MunitResult prs_TestParseExprPrecedence(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseFunctionCalls(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseDeleteStatement(const MunitParameter params[], void *user_data);
+MunitResult prs_TestParseIfStatements(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseImportStatement(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseMergeStatement(const MunitParameter params[], void *user_data);
 MunitResult prs_TestParseReturnStatement(const MunitParameter params[], void *user_data);


### PR DESCRIPTION
Parse `break`, `continue`, `delete`, `for`, `if`/`else if`/`else`, `import`, `merge`, and `return` statements and assignment/declaration statements as well. mscript code is now parsed into fully formed "modules" by the parser. At this point, the parser does not really perform any optimizations or verifications of the correctness of the parse tree (other than as correctness applies to the grammar rules of the language). There are some pieces missing too, such as object literals (noted in issue #14). Likewise, there are some other outstanding ideas such as multiple returns (issue #8) and swap style assignment (issue #9) that were not implemented in this particular branch.