### PR TITLE
Single error type (mscript C code)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,8 @@ set(LIBDS_SOURCE_FILES deps/libds/array.c
 set(STREAM_SOURCE_FILES lib/stream/streamreader.c)
 
 # mscript source files
-set(MSCRIPT_SOURCE_FILES src/bytecode.c
+set(MSCRIPT_SOURCE_FILES src/mscript.c
+                         src/bytecode.c
                          src/lang.c
                          src/lexer.c
                          src/obj.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(STREAM_SOURCE_FILES lib/stream/streamreader.c)
 # mscript source files
 set(MSCRIPT_SOURCE_FILES src/mscript.c
                          src/bytecode.c
+                         src/error.c
                          src/lang.c
                          src/lexer.c
                          src/obj.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ include_directories(${PROJECT_SOURCE_DIR}/deps)
 include_directories(${PROJECT_SOURCE_DIR}/lib)
 
 # Compiler and Linker flags
-set(C_WARNING_FLAGS "-Wall -Wextra -pedantic -Werror=return-type -Wno-missing-field-initializers")
+set(C_WARNING_FLAGS "-Wall -Wextra -pedantic -Werror=return-type -Wno-missing-field-initializers -Wno-format-security")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -g ${C_WARNING_FLAGS}")
 
 #######################################################################

--- a/src/bytecode.c
+++ b/src/bytecode.c
@@ -34,6 +34,7 @@ typedef struct {
     DSArray *values;
     DSArray *idents;
     DSDict *ident_cache;        /** cache of previously used identifier names */
+    ms_Error **err;
 } CodeGenContext;
 
 typedef struct {
@@ -108,12 +109,15 @@ static void PushOpCode(ms_VMOpCodeType type, int arg, CodeGenContext *ctx);
  * PUBLIC FUNCTIONS
  */
 
-ms_VMByteCode *ms_ASTToOpCodes(ms_AST *ast) {
-    if (!ast) { return NULL; }
+ms_Result ms_VMByteCodeGenerateFromAST(const ms_AST *ast, ms_VMByteCode **code, ms_Error **err) {
+    if (!ast) {
+        return MS_RESULT_ERROR;
+    }
 
-    CodeGenContext ctx = { NULL, NULL, NULL };
+    *err = NULL;
+    CodeGenContext ctx = { NULL, NULL, NULL, NULL, err };
     if (!CodeGenContextCreate(&ctx)) {
-        return NULL;
+        return MS_RESULT_ERROR;
     }
 
     size_t len = dsarray_len(ast);
@@ -122,9 +126,9 @@ ms_VMByteCode *ms_ASTToOpCodes(ms_AST *ast) {
         StmtToOpCodes(stmt, &ctx);
     }
 
-    ms_VMByteCode *bc = VMByteCodeNew(&ctx);
+    *code = VMByteCodeNew(&ctx);
     CodeGenContextClean(&ctx);
-    return bc;
+    return MS_RESULT_SUCCESS;
 }
 
 void ms_VMByteCodeDestroy(ms_VMByteCode *bc) {

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -18,6 +18,7 @@
 #define MSCRIPT_BYTECODE_H
 
 #include <stddef.h>
+#include "error.h"
 #include "lang.h"
 
 typedef enum {
@@ -135,7 +136,7 @@ struct ms_VMByteCode {
 /**
 * @brief Generate mscript VM bytecode from the given abstract syntax tree.
 */
-ms_VMByteCode *ms_ASTToOpCodes(ms_AST *ast);
+ms_Result ms_VMByteCodeGenerateFromAST(const ms_AST *ast, ms_VMByteCode **code, ms_Error **err);
 
 /**
 * @brief Print a representation of the bytecode format to the stdout.

--- a/src/error.c
+++ b/src/error.c
@@ -14,23 +14,23 @@
  *  limitations under the License.
  *----------------------------------------------------------------------------*/
 
-#ifndef MSCRIPT_MSCRIPT_H
-#define MSCRIPT_MSCRIPT_H
-
 #include "error.h"
 
-typedef struct ms_State ms_State;
+void ms_ErrorDestroy(ms_Error *err) {
+    if (!err) { return; }
 
-typedef struct {
-    bool print_bytecode;
-} ms_StateOptions;
+    switch (err->type) {
+        case MS_ERROR_PARSER:
+            ms_TokenDestroy(err->detail.parse.tok);
+            err->detail.parse.tok = NULL;
+            break;
+        case MS_ERROR_CODEGEN:
+            break;
+        case MS_ERROR_VM:
+            break;
+    }
 
-ms_State *ms_StateNew(void);
-ms_State *ms_StateNewOptions(ms_StateOptions opts);
-ms_Result ms_StateExecuteString(ms_State *state, const char *str, const ms_Error **err);
-ms_Result ms_StateExecuteStringL(ms_State *state, const char *str, size_t len, const ms_Error **err);
-ms_Result ms_StateExecuteFile(ms_State *state, const char *fname, const ms_Error **err);
-void ms_StateErrorClear(ms_State *state);
-void ms_StateDestroy(ms_State *state);
-
-#endif //MSCRIPT_MSCRIPT_H
+    free(err->msg);
+    err->msg = NULL;
+    free(err);
+}

--- a/src/error.h
+++ b/src/error.h
@@ -46,4 +46,6 @@ typedef struct {
     char *msg;                      /** Error message associated with the error */
 } ms_Error;
 
+void ms_ErrorDestroy(ms_Error *err);
+
 #endif //MSCRIPT_ERROR_H

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,49 @@
+/*------------------------------------------------------------------------------
+ *    Copyright 2016 Chris Rink
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *----------------------------------------------------------------------------*/
+
+#ifndef MSCRIPT_ERROR_H
+#define MSCRIPT_ERROR_H
+
+#include "lexer.h"
+
+typedef enum {
+    MS_RESULT_SUCCESS,              /** Operation succeeded without error */
+    MS_RESULT_WARNINGS,             /** Operation succeeded with non-fatal errors */
+    MS_RESULT_ERROR,               /** Operation could not be completed */
+} ms_Result;
+
+typedef enum {
+    MS_ERROR_PARSER,                /** Error occurred during parsing */
+    MS_ERROR_CODEGEN,               /** Error occurred during code generation */
+    MS_ERROR_VM,                    /** Error occurred during runtime in the VM */
+} ms_ErrorType;
+
+typedef struct {
+    ms_Token *tok;                  /** Token potentially associated with the error */
+} ms_ParseError;
+
+typedef union {
+    ms_ParseError parse;
+} ms_ErrorDetail;
+
+typedef struct {
+    ms_ErrorType type;
+    ms_ErrorDetail detail;
+    size_t len;                     /** Length of the error message */
+    char *msg;                      /** Error message associated with the error */
+} ms_Error;
+
+#endif //MSCRIPT_ERROR_H

--- a/src/main.c
+++ b/src/main.c
@@ -18,48 +18,32 @@
 #include <stdlib.h>
 #include <string.h>
 #include <readline/readline.h>
-#include "parser.h"
-#include "vm.h"
+#include "mscript.h"
 
 static int StartREPL(const char *prog) {
-    ms_Parser *prs = ms_ParserNew();
-    assert(prs);
-    ms_VM *vm = ms_VMNew();
-    assert(vm);
+    ms_StateOptions opts = {
+        .print_bytecode = true,
+    };
+    ms_State *ms = ms_StateNewOptions(opts);
+    assert(ms);
 
     char *input;
     printf("mscript v0.1\n");
     while ((input = readline("> ")) != NULL) {
         if (strlen(input) == 0) {
-            ms_VMClear(vm);
             free(input);
             break;
         }
 
-        ms_ParserInitString(prs, input);
-
-        ms_VMByteCode *code;    /* freed by the VM */
-        const ms_ParseError *err;
-        if (ms_ParserParse(prs, &code, NULL, &err) == PARSE_ERROR) {
+        const ms_Error *err;
+        if (ms_StateExecuteString(ms, input, &err) == MS_RESULT_ERROR) {
             printf("%s: \n%s\n", prog, err->msg);
-            free(input);
-            continue;
         }
 
-        assert(code);
-        assert(!err);
-
-        const ms_VMError *vmerr;
-        if (ms_VMExecuteAndPrint(vm, code, &vmerr) != VMEXEC_SUCCESS) {
-            printf("%s: \n%s\n", prog, vmerr->msg);
-        }
-
-        ms_VMClear(vm);
         free(input);
     }
 
-    ms_ParserDestroy(prs);
-    ms_VMDestroy(vm);
+    ms_StateDestroy(ms);
     return EXIT_SUCCESS;
 }
 

--- a/src/mscript.c
+++ b/src/mscript.c
@@ -75,7 +75,7 @@ ms_Result ms_StateExecuteStringL(ms_State *state, const char *str, size_t len, c
     }
 
     assert(code);
-    assert(!err);
+    assert(!(*err));
     if (state->opts.print_bytecode) {
         ms_VMByteCodePrint(code);
     }
@@ -104,7 +104,7 @@ ms_Result ms_StateExecuteFile(ms_State *state, const char *fname, const ms_Error
     }
 
     assert(code);
-    assert(!err);
+    assert(!(*err));
     if (state->opts.print_bytecode) {
         ms_VMByteCodePrint(code);
     }

--- a/src/mscript.c
+++ b/src/mscript.c
@@ -120,6 +120,7 @@ static ms_Result StateParseAndExecute(ms_State *state, const ms_Error **err) {
     assert(state);
     assert(err);
 
+    *err = NULL;
     ms_StateErrorClear(state);
 
     const ms_AST *ast;
@@ -135,16 +136,15 @@ static ms_Result StateParseAndExecute(ms_State *state, const ms_Error **err) {
         return MS_RESULT_ERROR;
     }
 
-    assert(!state->err);
     if (state->opts.print_bytecode) {
         ms_VMByteCodePrint(code);
     }
 
-    const ms_VMError *vmerr;
-    if (ms_VMExecuteAndPrint(state->vm, code, &vmerr) != VMEXEC_SUCCESS) {
+    assert(!state->err);
+    if (ms_VMExecuteAndPrint(state->vm, code, &state->err) == MS_RESULT_ERROR) {
+        *err = state->err;
         return MS_RESULT_ERROR;
     }
 
-    ms_VMClear(state->vm);
     return MS_RESULT_SUCCESS;
 }

--- a/src/mscript.c
+++ b/src/mscript.c
@@ -1,0 +1,128 @@
+/*------------------------------------------------------------------------------
+ *    Copyright 2016 Chris Rink
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *----------------------------------------------------------------------------*/
+
+#include <assert.h>
+#include <string.h>
+#include "mscript.h"
+#include "parser.h"
+#include "vm.h"
+
+struct ms_State {
+    ms_Parser *prs;
+    ms_VM *vm;
+    ms_StateOptions opts;
+};
+
+ms_State *ms_StateNew(void) {
+    ms_StateOptions opts = {
+        .print_bytecode = false,
+    };
+    return ms_StateNewOptions(opts);
+}
+
+ms_State *ms_StateNewOptions(ms_StateOptions opts) {
+    ms_State *state = malloc(sizeof(ms_State));
+    if (!state) {
+        return NULL;
+    }
+    state->opts = opts;
+
+    state->prs = ms_ParserNew();
+    if (!state->prs) {
+        free(state);
+        return NULL;
+    }
+
+    state->vm = ms_VMNew();
+    if (!state->vm) {
+        ms_ParserDestroy(state->prs);
+        free(state);
+        return NULL;
+    }
+
+    return state;
+}
+
+ms_Result ms_StateExecuteString(ms_State *state, const char *str, const ms_Error **err) {
+    return ms_StateExecuteStringL(state, str, strlen(str), err);
+}
+
+ms_Result ms_StateExecuteStringL(ms_State *state, const char *str, size_t len, const ms_Error **err) {
+    if (!state) {
+        return MS_RESULT_ERROR;
+    }
+
+    if (!ms_ParserInitStringL(state->prs, str, len)) {
+        return MS_RESULT_ERROR;
+    }
+
+    ms_VMByteCode *code;    /* freed by the VM */
+    if (ms_ParserParse(state->prs, &code, NULL, err) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
+    }
+
+    assert(code);
+    assert(!err);
+    if (state->opts.print_bytecode) {
+        ms_VMByteCodePrint(code);
+    }
+
+    const ms_VMError *vmerr;
+    if (ms_VMExecuteAndPrint(state->vm, code, &vmerr) != VMEXEC_SUCCESS) {
+        return MS_RESULT_ERROR;
+    }
+
+    //ms_VMClear(vm);
+    return MS_RESULT_SUCCESS;
+}
+
+ms_Result ms_StateExecuteFile(ms_State *state, const char *fname, const ms_Error **err) {
+    if (!state) {
+        return MS_RESULT_ERROR;
+    }
+
+    if (!ms_ParserInitFile(state->prs, fname)) {
+        return MS_RESULT_ERROR;
+    }
+
+    ms_VMByteCode *code;    /* freed by the VM */
+    if (ms_ParserParse(state->prs, &code, NULL, err) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
+    }
+
+    assert(code);
+    assert(!err);
+    if (state->opts.print_bytecode) {
+        ms_VMByteCodePrint(code);
+    }
+
+    const ms_VMError *vmerr;
+    if (ms_VMExecuteAndPrint(state->vm, code, &vmerr) != VMEXEC_SUCCESS) {
+        return MS_RESULT_ERROR;
+    }
+
+    //ms_VMClear(vm);
+    return MS_RESULT_SUCCESS;
+}
+
+void ms_StateDestroy(ms_State *state) {
+    if (!state) { return; }
+    ms_ParserDestroy(state->prs);
+    state->prs = NULL;
+    ms_VMDestroy(state->vm);
+    state->vm = NULL;
+    free(state);
+}

--- a/src/mscript.c
+++ b/src/mscript.c
@@ -124,12 +124,14 @@ static ms_Result StateParseAndExecute(ms_State *state, const ms_Error **err) {
 
     const ms_AST *ast;
     if (ms_ParserParse(state->prs, &ast, &state->err) == MS_RESULT_ERROR) {
+        *err = state->err;
         return MS_RESULT_ERROR;
     }
 
     assert(!state->err);
     ms_VMByteCode *code;    /* freed by the VM */
     if (ms_VMByteCodeGenerateFromAST(ast, &code, &state->err) == MS_RESULT_ERROR) {
+        *err = state->err;
         return MS_RESULT_ERROR;
     }
 

--- a/src/mscript.h
+++ b/src/mscript.h
@@ -1,0 +1,35 @@
+/*------------------------------------------------------------------------------
+ *    Copyright 2016 Chris Rink
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *----------------------------------------------------------------------------*/
+
+#ifndef MSCRIPT_MSCRIPT_H
+#define MSCRIPT_MSCRIPT_H
+
+#include "error.h"
+
+typedef struct ms_State ms_State;
+
+typedef struct {
+    bool print_bytecode;
+} ms_StateOptions;
+
+ms_State *ms_StateNew(void);
+ms_State *ms_StateNewOptions(ms_StateOptions opts);
+ms_Result ms_StateExecuteString(ms_State *state, const char *str, const ms_Error **err);
+ms_Result ms_StateExecuteStringL(ms_State *state, const char *str, size_t len, const ms_Error **err);
+ms_Result ms_StateExecuteFile(ms_State *state, const char *fname, const ms_Error **err);
+void ms_StateDestroy(ms_State *state);
+
+#endif //MSCRIPT_MSCRIPT_H

--- a/src/parser.c
+++ b/src/parser.c
@@ -25,6 +25,7 @@
 #include "parser.h"
 #include "lang.h"
 #include "vm.h"
+#include "error.h"
 
 /*
  * FORWARD DECLARATIONS
@@ -42,7 +43,7 @@ struct ms_Parser {
     size_t line;                            /** current line */
     size_t col;                             /** current column */
     ms_AST *ast;                            /** current abstract syntax tree */
-    ms_ParseError *err;                     /** current parser error */
+    ms_Error *err;                          /** current parser error */
 };
 
 static const char *const ERR_OUT_OF_MEMORY = "Out of memory";
@@ -58,56 +59,56 @@ static const char *const ERR_MUST_ASSIGN_TO_QIDENT = "Assignment target must be 
 static const char *const ERR_MUST_IMPORT_QIDENT = "Imported module must be identifier or qualified identifier (ln: %d, col: %d)";
 static const char *const ERR_FOR_LOOP_MUST_END = "For loop must have a start expression and end expression (ln: %d, col: %d)";
 
-static ms_ParseResult ParserParseModule(ms_Parser *prs, ms_Module **module);
-static ms_ParseResult ParserParseStatement(ms_Parser *prs, ms_Stmt **stmt);
-static ms_ParseResult ParserParseBlock(ms_Parser *prs, ms_StmtBlock **block);
-static ms_ParseResult ParserParseDeleteStatement(ms_Parser *prs, ms_StmtDelete **del);
-static ms_ParseResult ParserParseForStatement(ms_Parser *prs, ms_StmtFor **forstmt);
-static ms_ParseResult ParserParseForIncrement(ms_Parser *prs, ms_Expr *ident, bool declare, ms_StmtForIncrement **inc, ms_StmtBlock **block);
-static ms_ParseResult ParserParseForIterator(ms_Parser *prs, ms_Expr *ident, bool declare, ms_StmtForIterator **iter, ms_StmtBlock **block);
-static ms_ParseResult ParserParseForExpr(ms_Parser *prs, ms_Expr *expr, ms_StmtForExpr **forexpr, ms_StmtBlock **block);
-static ms_ParseResult ParserParseIfStatement(ms_Parser *prs, ms_StmtIf **ifstmt);
-static ms_ParseResult ParserParseElseStatement(ms_Parser *prs, ms_StmtIfElse **elif);
-static ms_ParseResult ParserParseImportStatement(ms_Parser *prs, ms_StmtImport **import);
-static ms_ParseResult ParserParseMergeStatement(ms_Parser *prs, ms_StmtMerge **merge);
-static ms_ParseResult ParserParseReturnStatement(ms_Parser *prs, ms_StmtReturn **ret);
-static ms_ParseResult ParserParseFunctionDeclaration(ms_Parser *prs, ms_StmtDeclaration **decl);
-static ms_ParseResult ParserParseDeclaration(ms_Parser *prs, bool req_keyword, ms_StmtDeclaration **decl);
-static ms_ParseResult ParserParseAssignment(ms_Parser *prs, ms_Stmt **stmt);
-static ms_ParseResult ParserParseSimpleAssignment(ms_Parser *prs, ms_Expr *name, ms_Stmt **stmt);
-static ms_ParseResult ParserParseCompoundAssignment(ms_Parser *prs, ms_Expr *name, ms_Stmt **stmt);
-static ms_ParseResult ParserParseStatementTerminator(ms_Parser *prs);
-static ms_ParseResult ParserParseExpression(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseSelectExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseSelectBody(ms_Parser *prs, bool saw_full_pair, ms_Expr **select);
-static ms_ParseResult ParserParseConditionalExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseOrExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseAndExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseEqualityExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseComparisonExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseBitwiseOrExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseBitwiseXorExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseBitwiseAndExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseBitShiftExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseArithmeticExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseTermExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParsePowerExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseUnaryExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseAtomExpr(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseAccessor(ms_Parser *prs, ms_Expr **expr, ms_ExprBinaryOp *op);
-static ms_ParseResult ParserParseExprList(ms_Parser *prs, ms_Expr **list, ms_TokenType closer);
-static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr);
-static ms_ParseResult ParserParseFunctionExpression(ms_Parser *prs, bool require_name, ms_Expr **expr);
-static ms_ParseResult ParserExprRewriteAttrAccess(ms_Parser *prs, ms_Expr *left, ms_ExprBinaryOp op, ms_Expr *right, ms_Expr **newexpr);
-static ms_ParseResult ParserExprCombineConditional(ms_Parser *prs, ms_Expr *cond, ms_Expr *iftrue, ms_Expr *iffalse, ms_Expr **newexpr);
-static ms_ParseResult ParserExprCombineBinary(ms_Parser *prs, ms_Expr *left, ms_ExprBinaryOp op, ms_Expr *right, ms_Expr **newexpr);
-static ms_ParseResult ParserExprCombineUnary(ms_Parser *prs, ms_Expr *inner, ms_ExprUnaryOp op, ms_Expr **newexpr);
+static ms_Result ParserParseModule(ms_Parser *prs, ms_Module **module);
+static ms_Result ParserParseStatement(ms_Parser *prs, ms_Stmt **stmt);
+static ms_Result ParserParseBlock(ms_Parser *prs, ms_StmtBlock **block);
+static ms_Result ParserParseDeleteStatement(ms_Parser *prs, ms_StmtDelete **del);
+static ms_Result ParserParseForStatement(ms_Parser *prs, ms_StmtFor **forstmt);
+static ms_Result ParserParseForIncrement(ms_Parser *prs, ms_Expr *ident, bool declare, ms_StmtForIncrement **inc, ms_StmtBlock **block);
+static ms_Result ParserParseForIterator(ms_Parser *prs, ms_Expr *ident, bool declare, ms_StmtForIterator **iter, ms_StmtBlock **block);
+static ms_Result ParserParseForExpr(ms_Parser *prs, ms_Expr *expr, ms_StmtForExpr **forexpr, ms_StmtBlock **block);
+static ms_Result ParserParseIfStatement(ms_Parser *prs, ms_StmtIf **ifstmt);
+static ms_Result ParserParseElseStatement(ms_Parser *prs, ms_StmtIfElse **elif);
+static ms_Result ParserParseImportStatement(ms_Parser *prs, ms_StmtImport **import);
+static ms_Result ParserParseMergeStatement(ms_Parser *prs, ms_StmtMerge **merge);
+static ms_Result ParserParseReturnStatement(ms_Parser *prs, ms_StmtReturn **ret);
+static ms_Result ParserParseFunctionDeclaration(ms_Parser *prs, ms_StmtDeclaration **decl);
+static ms_Result ParserParseDeclaration(ms_Parser *prs, bool req_keyword, ms_StmtDeclaration **decl);
+static ms_Result ParserParseAssignment(ms_Parser *prs, ms_Stmt **stmt);
+static ms_Result ParserParseSimpleAssignment(ms_Parser *prs, ms_Expr *name, ms_Stmt **stmt);
+static ms_Result ParserParseCompoundAssignment(ms_Parser *prs, ms_Expr *name, ms_Stmt **stmt);
+static ms_Result ParserParseStatementTerminator(ms_Parser *prs);
+static ms_Result ParserParseExpression(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseSelectExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseSelectBody(ms_Parser *prs, bool saw_full_pair, ms_Expr **select);
+static ms_Result ParserParseConditionalExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseOrExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseAndExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseEqualityExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseComparisonExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseBitwiseOrExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseBitwiseXorExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseBitwiseAndExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseBitShiftExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseArithmeticExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseTermExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParsePowerExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseUnaryExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseAtomExpr(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseAccessor(ms_Parser *prs, ms_Expr **expr, ms_ExprBinaryOp *op);
+static ms_Result ParserParseExprList(ms_Parser *prs, ms_Expr **list, ms_TokenType closer);
+static ms_Result ParserParseAtom(ms_Parser *prs, ms_Expr **expr);
+static ms_Result ParserParseFunctionExpression(ms_Parser *prs, bool require_name, ms_Expr **expr);
+static ms_Result ParserExprRewriteAttrAccess(ms_Parser *prs, ms_Expr *left, ms_ExprBinaryOp op, ms_Expr *right, ms_Expr **newexpr);
+static ms_Result ParserExprCombineConditional(ms_Parser *prs, ms_Expr *cond, ms_Expr *iftrue, ms_Expr *iffalse, ms_Expr **newexpr);
+static ms_Result ParserExprCombineBinary(ms_Parser *prs, ms_Expr *left, ms_ExprBinaryOp op, ms_Expr *right, ms_Expr **newexpr);
+static ms_Result ParserExprCombineUnary(ms_Parser *prs, ms_Expr *inner, ms_ExprUnaryOp op, ms_Expr **newexpr);
 
 static inline ms_Token *ParserAdvanceToken(ms_Parser *prs);
 static inline void ParserConsumeToken(ms_Parser *prs);
-static bool ParserExpectToken(ms_Parser *prs, ms_TokenType type);
+static inline bool ParserExpectToken(ms_Parser *prs, ms_TokenType type);
 static void ParserErrorSet(ms_Parser *prs, const char* msg, const ms_Token *tok, ...);
-static void ParseErrorDestroy(ms_ParseError *err);
+static void ParseErrorDestroy(ms_Error *err);
 
 /*
  * PUBLIC FUNCTIONS
@@ -196,7 +197,7 @@ bool ms_ParserInitStringL(ms_Parser *prs, const char *str, size_t len) {
     return true;
 }
 
-ms_ParseResult ms_ParserParse(ms_Parser *prs, ms_VMByteCode **code, const ms_AST **ast, const ms_ParseError **err) {
+ms_Result ms_ParserParse(ms_Parser *prs, ms_VMByteCode **code, const ms_AST **ast, const ms_Error **err) {
     assert(prs);
     assert(code);
     assert(err);
@@ -207,15 +208,15 @@ ms_ParseResult ms_ParserParse(ms_Parser *prs, ms_VMByteCode **code, const ms_AST
     }
 
     *err = NULL;
-    ms_ParseResult res = ParserParseModule(prs, &prs->ast);
+    ms_Result res = ParserParseModule(prs, &prs->ast);
 
-    if ((res != PARSE_ERROR) && (prs->cur)) {
+    if ((res != MS_RESULT_ERROR) && (prs->cur)) {
         ParserErrorSet(prs, ERR_INVALID_SYNTAX_GOT_TOK, prs->cur,
                        dsbuf_char_ptr(prs->cur->value), prs->line, prs->col);
-        res = PARSE_ERROR;
+        res = MS_RESULT_ERROR;
     }
 
-    if (res == PARSE_ERROR) {
+    if (res == MS_RESULT_ERROR) {
         *err = prs->err;
         *code = NULL;
     } else {
@@ -309,7 +310,7 @@ void ms_ParserDestroy(ms_Parser *prs) {
  * or whenever the parser is reinitialized with a new file or string.
  */
 
-static ms_ParseResult ParserParseModule(ms_Parser *prs, ms_Module **module) {
+static ms_Result ParserParseModule(ms_Parser *prs, ms_Module **module) {
     assert(prs);
     assert(module);
 
@@ -317,37 +318,37 @@ static ms_ParseResult ParserParseModule(ms_Parser *prs, ms_Module **module) {
                               (dsarray_free_fn)ms_StmtDestroy);
     if (!(*module)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     while (prs->cur) {
         ms_Stmt *stmt = NULL;
-        if (ParserParseStatement(prs, &stmt) == PARSE_ERROR) {
+        if (ParserParseStatement(prs, &stmt) == MS_RESULT_ERROR) {
             ms_StmtDestroy(stmt);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
         dsarray_append(*module, stmt);
     }
 
-    return PARSE_SUCCESS;
+    return MS_RESULT_SUCCESS;
 }
 
-static ms_ParseResult ParserParseStatement(ms_Parser *prs, ms_Stmt **stmt) {
+static ms_Result ParserParseStatement(ms_Parser *prs, ms_Stmt **stmt) {
     assert(prs);
     assert(stmt);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Token *cur = prs->cur;
 
     if (!cur) {
         ParserErrorSet(prs, ERR_EXPECTED_STATEMENT, NULL, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     *stmt = calloc(1, sizeof(ms_Stmt));
     if (!(*stmt)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
     (*stmt)->type = STMTTYPE_EMPTY;
 
@@ -404,7 +405,7 @@ static ms_ParseResult ParserParseStatement(ms_Parser *prs, ms_Stmt **stmt) {
         default:
             (*stmt)->type = STMTTYPE_EXPRESSION;
             res = ParserParseExpression(prs, &(*stmt)->cmpnt.expr);
-            if (res != PARSE_ERROR) {
+            if (res != MS_RESULT_ERROR) {
                 res = ParserParseStatementTerminator(prs);
             }
             break;
@@ -413,7 +414,7 @@ static ms_ParseResult ParserParseStatement(ms_Parser *prs, ms_Stmt **stmt) {
     return res;
 }
 
-static ms_ParseResult ParserParseBlock(ms_Parser *prs, ms_StmtBlock **block) {
+static ms_Result ParserParseBlock(ms_Parser *prs, ms_StmtBlock **block) {
     assert(prs);
     assert(block);
 
@@ -421,21 +422,21 @@ static ms_ParseResult ParserParseBlock(ms_Parser *prs, ms_StmtBlock **block) {
                              (dsarray_free_fn)ms_StmtDestroy);
     if (!(*block)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, LBRACE)) {
         ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, "{", prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
 
     while ((prs->cur) && (!ParserExpectToken(prs, RBRACE))) {
         ms_Stmt *stmt = NULL;
-        if (ParserParseStatement(prs, &stmt) == PARSE_ERROR) {
+        if (ParserParseStatement(prs, &stmt) == MS_RESULT_ERROR) {
             ms_StmtDestroy(stmt);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
         if (ParserExpectToken(prs, RBRACE)) {
             dsarray_append(*block, stmt);
@@ -446,49 +447,49 @@ static ms_ParseResult ParserParseBlock(ms_Parser *prs, ms_StmtBlock **block) {
 
     if (!ParserExpectToken(prs, RBRACE)) {
         ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, "}", prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
-    return PARSE_SUCCESS;
+    return MS_RESULT_SUCCESS;
 }
 
-static ms_ParseResult ParserParseDeleteStatement(ms_Parser *prs, ms_StmtDelete **del) {
+static ms_Result ParserParseDeleteStatement(ms_Parser *prs, ms_StmtDelete **del) {
     assert(prs);
     assert(del);
 
     *del = calloc(1, sizeof(ms_StmtDelete));
     if (!(*del)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, KW_DEL)) {
         ParserErrorSet(prs, ERR_EXPECTED_KEYWORD, prs->cur, TOK_KW_DEL, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
-    if (ParserParseExpression(prs, &(*del)->expr) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &(*del)->expr) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     return ParserParseStatementTerminator(prs);
 }
 
-static ms_ParseResult ParserParseForStatement(ms_Parser *prs, ms_StmtFor **forstmt) {
+static ms_Result ParserParseForStatement(ms_Parser *prs, ms_StmtFor **forstmt) {
     assert(prs);
     assert(forstmt);
 
     *forstmt = calloc(1, sizeof(ms_StmtFor));
     if (!(*forstmt)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, KW_FOR)) {
         ParserErrorSet(prs, ERR_EXPECTED_KEYWORD, prs->cur, TOK_KW_FOR, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
     ParserConsumeToken(prs);
 
@@ -502,8 +503,8 @@ static ms_ParseResult ParserParseForStatement(ms_Parser *prs, ms_StmtFor **forst
     /* parse the next expression (which may be the identifer for certain
      * types of for statements) */
     ms_Expr *ident;
-    if (ParserParseExpression(prs, &ident) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &ident) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     /* determine if this is an iterator or increment style for statement */
@@ -521,7 +522,7 @@ static ms_ParseResult ParserParseForStatement(ms_Parser *prs, ms_StmtFor **forst
     if (declare) {
         ms_ExprDestroy(ident);
         ParserErrorSet(prs, ERR_EXPECTED_EXPRESSION, prs->cur, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     /* generic single expression FOR statement */
@@ -529,7 +530,7 @@ static ms_ParseResult ParserParseForStatement(ms_Parser *prs, ms_StmtFor **forst
     return ParserParseForExpr(prs, ident, &(*forstmt)->clause.expr, &(*forstmt)->block);
 }
 
-static ms_ParseResult ParserParseForIncrement(ms_Parser *prs, ms_Expr *ident, bool declare, ms_StmtForIncrement **inc, ms_StmtBlock **block) {
+static ms_Result ParserParseForIncrement(ms_Parser *prs, ms_Expr *ident, bool declare, ms_StmtForIncrement **inc, ms_StmtBlock **block) {
     assert(prs);
     assert(ident);
     assert(inc);
@@ -540,7 +541,7 @@ static ms_ParseResult ParserParseForIncrement(ms_Parser *prs, ms_Expr *ident, bo
         if (ident_type != EXPRIDENT_NAME) {
             ms_ExprDestroy(ident);
             ParserErrorSet(prs, ERR_MUST_ASSIGN_TO_IDENT, prs->cur, prs->line, prs->col);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
     } else {
         if ((ident_type != EXPRIDENT_NAME) &&
@@ -548,31 +549,31 @@ static ms_ParseResult ParserParseForIncrement(ms_Parser *prs, ms_Expr *ident, bo
             (ident_type != EXPRIDENT_GLOBAL)) {
             ms_ExprDestroy(ident);
             ParserErrorSet(prs, ERR_MUST_ASSIGN_TO_QIDENT, prs->cur, prs->line, prs->col);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
     }
 
     *inc = calloc(1, sizeof(ms_StmtForIncrement));
     if (!(*inc)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
     (*inc)->declare = declare;
     (*inc)->ident = ident;
 
-    if (ParserParseExpression(prs, &(*inc)->init) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &(*inc)->init) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, COLON)) {
         ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, TOK_COLON, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
     ParserConsumeToken(prs);
 
-    if (ParserParseExpression(prs, &(*inc)->end) == PARSE_ERROR) {
+    if (ParserParseExpression(prs, &(*inc)->end) == MS_RESULT_ERROR) {
         ParserErrorSet(prs, ERR_FOR_LOOP_MUST_END, prs->cur, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, COLON)) {
@@ -581,22 +582,22 @@ static ms_ParseResult ParserParseForIncrement(ms_Parser *prs, ms_Expr *ident, bo
         (*inc)->step = ms_ExprNewWithVal(MSVAL_INT, p);
         if (!(*inc)->step) {
             ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
 
         goto parse_for_inc_block;
     }
     ParserConsumeToken(prs);
 
-    if (ParserParseExpression(prs, &(*inc)->step) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &(*inc)->step) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
 parse_for_inc_block:
     return ParserParseBlock(prs, block);
 }
 
-static ms_ParseResult ParserParseForIterator(ms_Parser *prs, ms_Expr *ident, bool declare, ms_StmtForIterator **iter, ms_StmtBlock **block) {
+static ms_Result ParserParseForIterator(ms_Parser *prs, ms_Expr *ident, bool declare, ms_StmtForIterator **iter, ms_StmtBlock **block) {
     assert(prs);
     assert(ident);
     assert(iter);
@@ -607,7 +608,7 @@ static ms_ParseResult ParserParseForIterator(ms_Parser *prs, ms_Expr *ident, boo
         if (ident_type != EXPRIDENT_NAME) {
             ms_ExprDestroy(ident);
             ParserErrorSet(prs, ERR_MUST_ASSIGN_TO_IDENT, prs->cur, prs->line, prs->col);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
     } else {
         if ((ident_type != EXPRIDENT_NAME) &&
@@ -615,26 +616,26 @@ static ms_ParseResult ParserParseForIterator(ms_Parser *prs, ms_Expr *ident, boo
             (ident_type != EXPRIDENT_GLOBAL)) {
             ms_ExprDestroy(ident);
             ParserErrorSet(prs, ERR_MUST_ASSIGN_TO_QIDENT, prs->cur, prs->line, prs->col);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
     }
 
     *iter = calloc(1, sizeof(ms_StmtForIterator));
     if (!(*iter)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
     (*iter)->declare = declare;
     (*iter)->ident = ident;
 
-    if (ParserParseExpression(prs, &(*iter)->iter) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &(*iter)->iter) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     return ParserParseBlock(prs, block);
 }
 
-static ms_ParseResult ParserParseForExpr(ms_Parser *prs, ms_Expr *expr, ms_StmtForExpr **forexpr, ms_StmtBlock **block) {
+static ms_Result ParserParseForExpr(ms_Parser *prs, ms_Expr *expr, ms_StmtForExpr **forexpr, ms_StmtBlock **block) {
     assert(prs);
     assert(expr);
     assert(forexpr);
@@ -643,56 +644,56 @@ static ms_ParseResult ParserParseForExpr(ms_Parser *prs, ms_Expr *expr, ms_StmtF
     if (!(*forexpr)) {
         ms_ExprDestroy(expr);
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
     (*forexpr)->expr = expr;
     return ParserParseBlock(prs, block);
 }
 
-static ms_ParseResult ParserParseIfStatement(ms_Parser *prs, ms_StmtIf **ifstmt) {
+static ms_Result ParserParseIfStatement(ms_Parser *prs, ms_StmtIf **ifstmt) {
     assert(prs);
     assert(ifstmt);
 
     *ifstmt = calloc(1, sizeof(ms_StmtIf));
     if (!(*ifstmt)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, KW_IF)) {
         ParserErrorSet(prs, ERR_EXPECTED_KEYWORD, prs->cur, TOK_KW_IF, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
-    if (ParserParseExpression(prs, &(*ifstmt)->expr) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &(*ifstmt)->expr) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
-    if (ParserParseBlock(prs, &(*ifstmt)->block) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseBlock(prs, &(*ifstmt)->block) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, KW_ELSE)) {
-        return PARSE_SUCCESS;
+        return MS_RESULT_SUCCESS;
     }
 
     return ParserParseElseStatement(prs, &(*ifstmt)->elif);
 }
 
-static ms_ParseResult ParserParseElseStatement(ms_Parser *prs, ms_StmtIfElse **elif) {
+static ms_Result ParserParseElseStatement(ms_Parser *prs, ms_StmtIfElse **elif) {
     assert(prs);
     assert(elif);
 
     *elif = calloc(1, sizeof(ms_StmtIfElse));
     if (!(*elif)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, KW_ELSE)) {
         ParserErrorSet(prs, ERR_EXPECTED_KEYWORD, prs->cur, TOK_KW_ELSE, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
@@ -704,37 +705,37 @@ static ms_ParseResult ParserParseElseStatement(ms_Parser *prs, ms_StmtIfElse **e
     (*elif)->clause.elstmt = malloc(sizeof(ms_StmtElse));
     if (!(*elif)->clause.elstmt) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     (*elif)->type = IFELSE_ELSE;
     return ParserParseBlock(prs, &(*elif)->clause.elstmt->block);
 }
 
-static ms_ParseResult ParserParseImportStatement(ms_Parser *prs, ms_StmtImport **import) {
+static ms_Result ParserParseImportStatement(ms_Parser *prs, ms_StmtImport **import) {
     assert(prs);
     assert(import);
 
     *import = calloc(1, sizeof(ms_StmtImport));
     if (!(*import)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, KW_IMPORT)) {
         ParserErrorSet(prs, ERR_EXPECTED_KEYWORD, prs->cur, TOK_KW_IMPORT, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
-    if (ParserParseExpression(prs, &(*import)->ident) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &(*import)->ident) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     ms_ExprIdentType ident_type = ms_ExprGetIdentType((*import)->ident);
     if ((ident_type != EXPRIDENT_NAME) && (ident_type != EXPRIDENT_QUALIFIED)) {
         ParserErrorSet(prs, ERR_MUST_IMPORT_QIDENT, prs->cur, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, COLON)) {
@@ -745,14 +746,14 @@ static ms_ParseResult ParserParseImportStatement(ms_Parser *prs, ms_StmtImport *
 
     if (!ParserExpectToken(prs, IDENTIFIER)) {
         ParserErrorSet(prs, ERR_EXPECTED_IDENTIFIER, prs->cur, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     /* steal the identifier from the token */
     (*import)->alias = malloc(sizeof(ms_Ident));
     if (!(*import)->alias) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     (*import)->alias->name = prs->cur->value;
@@ -762,52 +763,52 @@ static ms_ParseResult ParserParseImportStatement(ms_Parser *prs, ms_StmtImport *
     return ParserParseStatementTerminator(prs);
 }
 
-static ms_ParseResult ParserParseMergeStatement(ms_Parser *prs, ms_StmtMerge **merge) {
+static ms_Result ParserParseMergeStatement(ms_Parser *prs, ms_StmtMerge **merge) {
     assert(prs);
     assert(merge);
 
     *merge = calloc(1, sizeof(ms_StmtMerge));
     if (!(*merge)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, KW_MERGE)) {
         ParserErrorSet(prs, ERR_EXPECTED_KEYWORD, prs->cur, TOK_KW_MERGE, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
-    if (ParserParseExpression(prs, &(*merge)->left) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &(*merge)->left) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, OP_EQ)) {
         ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, TOK_OP_EQ, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
-    if (ParserParseExpression(prs, &(*merge)->right) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &(*merge)->right) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     return ParserParseStatementTerminator(prs);
 }
 
-static ms_ParseResult ParserParseReturnStatement(ms_Parser *prs, ms_StmtReturn **ret) {
+static ms_Result ParserParseReturnStatement(ms_Parser *prs, ms_StmtReturn **ret) {
     assert(prs);
     assert(ret);
 
     *ret = calloc(1, sizeof(ms_StmtReturn));
     if (!(*ret)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, KW_RETURN)) {
         ParserErrorSet(prs, ERR_EXPECTED_KEYWORD, prs->cur, TOK_KW_RETURN, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
@@ -818,74 +819,74 @@ static ms_ParseResult ParserParseReturnStatement(ms_Parser *prs, ms_StmtReturn *
         (*ret)->expr = ms_ExprNewWithVal(MSVAL_NULL, p);
         if (!(*ret)->expr) {
             ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
 
         return ParserParseStatementTerminator(prs);
     }
 
-    if (ParserParseExpression(prs, &(*ret)->expr) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &(*ret)->expr) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     return ParserParseStatementTerminator(prs);
 }
 
-static ms_ParseResult ParserParseFunctionDeclaration(ms_Parser *prs, ms_StmtDeclaration **decl) {
+static ms_Result ParserParseFunctionDeclaration(ms_Parser *prs, ms_StmtDeclaration **decl) {
     assert(prs);
     assert(decl);
 
     *decl = calloc(1, sizeof(ms_StmtDeclaration));
     if (!(*decl)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
-    if (ParserParseFunctionExpression(prs, true, &(*decl)->expr) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseFunctionExpression(prs, true, &(*decl)->expr) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     const ms_Ident *ident = (*decl)->expr->cmpnt.u->atom.val.val.fn->ident;  /* just... lol */
     (*decl)->ident = malloc(sizeof(ms_Ident));
     if (!(*decl)->ident) {
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     (*decl)->ident->name = dsbuf_dup(ident->name);
     (*decl)->ident->type = ident->type;
     if (!(*decl)->ident->name) {
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
-    return PARSE_SUCCESS;
+    return MS_RESULT_SUCCESS;
 }
 
-static ms_ParseResult ParserParseDeclaration(ms_Parser *prs, bool req_keyword, ms_StmtDeclaration **decl) {
+static ms_Result ParserParseDeclaration(ms_Parser *prs, bool req_keyword, ms_StmtDeclaration **decl) {
     assert(prs);
     assert(decl);
 
     *decl = calloc(1, sizeof(ms_StmtDeclaration));
     if (!(*decl)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     if ((req_keyword) && (!ParserExpectToken(prs, KW_VAR))) {
         ParserErrorSet(prs, ERR_EXPECTED_KEYWORD, prs->cur, TOK_KW_VAR, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
     if (!ParserExpectToken(prs, IDENTIFIER)) {
         ParserErrorSet(prs, ERR_EXPECTED_IDENTIFIER, prs->cur, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     /* take the identifier from the current token so the buffer isn't destroyed */
     (*decl)->ident = malloc(sizeof(ms_Ident));
     if (!(*decl)->ident) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     (*decl)->ident->name = prs->cur->value;
@@ -904,8 +905,8 @@ static ms_ParseResult ParserParseDeclaration(ms_Parser *prs, bool req_keyword, m
     }
 
     ParserConsumeToken(prs);
-    if (ParserParseExpression(prs, &(*decl)->expr) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &(*decl)->expr) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     /* allow multiple comma separated declarations */
@@ -916,13 +917,13 @@ static ms_ParseResult ParserParseDeclaration(ms_Parser *prs, bool req_keyword, m
     return ParserParseStatementTerminator(prs);
 }
 
-static ms_ParseResult ParserParseAssignment(ms_Parser *prs, ms_Stmt **stmt) {
+static ms_Result ParserParseAssignment(ms_Parser *prs, ms_Stmt **stmt) {
     assert(prs);
     assert(stmt);
 
     ms_Expr *name;
-    if (ParserParseExpression(prs, &name) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &name) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     /* some sort of assignment (simple or compound) */
@@ -933,12 +934,12 @@ static ms_ParseResult ParserParseAssignment(ms_Parser *prs, ms_Stmt **stmt) {
             (ident_type != EXPRIDENT_GLOBAL)) {
             ms_ExprDestroy(name);
             ParserErrorSet(prs, ERR_MUST_ASSIGN_TO_QIDENT, prs->cur, prs->line, prs->col);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
 
-        if (ParserParseSimpleAssignment(prs, name, stmt) == PARSE_ERROR) {
+        if (ParserParseSimpleAssignment(prs, name, stmt) == MS_RESULT_ERROR) {
             ms_ExprDestroy(name);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
 
         return ParserParseStatementTerminator(prs);
@@ -959,12 +960,12 @@ static ms_ParseResult ParserParseAssignment(ms_Parser *prs, ms_Stmt **stmt) {
             (ident_type != EXPRIDENT_GLOBAL)) {
             ms_ExprDestroy(name);
             ParserErrorSet(prs, ERR_MUST_ASSIGN_TO_QIDENT, prs->cur, prs->line, prs->col);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
 
-        if (ParserParseCompoundAssignment(prs, name, stmt) == PARSE_ERROR) {
+        if (ParserParseCompoundAssignment(prs, name, stmt) == MS_RESULT_ERROR) {
             ms_ExprDestroy(name);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
 
         return ParserParseStatementTerminator(prs);
@@ -976,7 +977,7 @@ static ms_ParseResult ParserParseAssignment(ms_Parser *prs, ms_Stmt **stmt) {
     return ParserParseStatementTerminator(prs);
 }
 
-static ms_ParseResult ParserParseSimpleAssignment(ms_Parser *prs, ms_Expr *name, ms_Stmt **stmt) {
+static ms_Result ParserParseSimpleAssignment(ms_Parser *prs, ms_Expr *name, ms_Stmt **stmt) {
     assert(prs);
     assert(name);
     assert(stmt);
@@ -985,7 +986,7 @@ static ms_ParseResult ParserParseSimpleAssignment(ms_Parser *prs, ms_Expr *name,
     (*stmt)->cmpnt.assign = calloc(1, sizeof(ms_StmtAssignment));
     if (!((*stmt)->cmpnt.assign)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     (*stmt)->type = STMTTYPE_ASSIGNMENT;
@@ -993,7 +994,7 @@ static ms_ParseResult ParserParseSimpleAssignment(ms_Parser *prs, ms_Expr *name,
     return ParserParseExpression(prs, &(*stmt)->cmpnt.assign->expr);
 }
 
-static ms_ParseResult ParserParseCompoundAssignment(ms_Parser *prs, ms_Expr *name, ms_Stmt **stmt) {
+static ms_Result ParserParseCompoundAssignment(ms_Parser *prs, ms_Expr *name, ms_Stmt **stmt) {
     assert(prs);
     assert(name);
     assert(stmt);
@@ -1019,7 +1020,7 @@ static ms_ParseResult ParserParseCompoundAssignment(ms_Parser *prs, ms_Expr *nam
     (*stmt)->cmpnt.assign = calloc(1, sizeof(ms_StmtAssignment));
     if (!((*stmt)->cmpnt.assign)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     (*stmt)->type = STMTTYPE_ASSIGNMENT;
@@ -1027,8 +1028,8 @@ static ms_ParseResult ParserParseCompoundAssignment(ms_Parser *prs, ms_Expr *nam
     ms_Expr *right = NULL;
 
     /* parse the right piece of the expanded compound expression  */
-    if (ParserParseExpression(prs, &right) == PARSE_ERROR) {
-        return PARSE_ERROR;
+    if (ParserParseExpression(prs, &right) == MS_RESULT_ERROR) {
+        return MS_RESULT_ERROR;
     }
 
     /* duplicate the identifier expression being set to be used in
@@ -1037,34 +1038,34 @@ static ms_ParseResult ParserParseCompoundAssignment(ms_Parser *prs, ms_Expr *nam
     if (!left) {
         ms_ExprDestroy(right);
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     /* combine the two pieces of the compound expression */
     ms_Expr *combined;
-    if (ParserExprCombineBinary(prs, left, op, right, &combined) == PARSE_ERROR) {
+    if (ParserExprCombineBinary(prs, left, op, right, &combined) == MS_RESULT_ERROR) {
         ms_ExprDestroy(left);
         ms_ExprDestroy(right);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     (*stmt)->cmpnt.assign->expr = combined;
-    return PARSE_SUCCESS;
+    return MS_RESULT_SUCCESS;
 }
 
-static ms_ParseResult ParserParseStatementTerminator(ms_Parser *prs) {
+static ms_Result ParserParseStatementTerminator(ms_Parser *prs) {
     assert(prs);
 
     if (!ParserExpectToken(prs, SEMICOLON)) {
         ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, ";", prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
-    return PARSE_SUCCESS;
+    return MS_RESULT_SUCCESS;
 }
 
-static ms_ParseResult ParserParseExpression(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseExpression(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
     return (prs->cur->type == KW_SELECT) ?
@@ -1072,32 +1073,32 @@ static ms_ParseResult ParserParseExpression(ms_Parser *prs, ms_Expr **expr) {
            ParserParseConditionalExpr(prs, expr);
 }
 
-static ms_ParseResult ParserParseSelectExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseSelectExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
     if (!ParserExpectToken(prs, KW_SELECT)) {
         ParserErrorSet(prs, ERR_EXPECTED_KEYWORD, prs->cur, "select", prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
     if (!ParserExpectToken(prs, LPAREN)) {
         ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, "(", prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
     return ParserParseSelectBody(prs, false, expr);
 }
 
-static ms_ParseResult ParserParseSelectBody(ms_Parser *prs, bool saw_full_pair, ms_Expr **select) {
+static ms_Result ParserParseSelectBody(ms_Parser *prs, bool saw_full_pair, ms_Expr **select) {
     assert(prs);
     assert(select);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *cond;
-    if ((res = ParserParseConditionalExpr(prs, &cond)) == PARSE_ERROR) {
+    if ((res = ParserParseConditionalExpr(prs, &cond)) == MS_RESULT_ERROR) {
         return res;
     }
 
@@ -1106,24 +1107,24 @@ static ms_ParseResult ParserParseSelectBody(ms_Parser *prs, bool saw_full_pair, 
         /* we needed one expression pair, but did not get one */
         ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, ":", prs->line, prs->col);
         ms_ExprDestroy(cond);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     } else if ((saw_full_pair) && (!next_is_colon)) {
         /* we expected a closing parent but didn't get one */
         if (!ParserExpectToken(prs, RPAREN)) {
             ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, ")", prs->line, prs->col);
             ms_ExprDestroy(cond);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
 
         /* condition becomes the "default" expression value */
         ParserConsumeToken(prs);
         *select = cond;
-        return PARSE_SUCCESS;
+        return MS_RESULT_SUCCESS;
     }
 
     ParserConsumeToken(prs);
     ms_Expr *iftrue;
-    if ((res = ParserParseConditionalExpr(prs, &iftrue)) == PARSE_ERROR) {
+    if ((res = ParserParseConditionalExpr(prs, &iftrue)) == MS_RESULT_ERROR) {
         ms_ExprDestroy(cond);
         return res;
     }
@@ -1138,11 +1139,11 @@ static ms_ParseResult ParserParseSelectBody(ms_Parser *prs, bool saw_full_pair, 
         ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, ",", prs->line, prs->col);
         ms_ExprDestroy(cond);
         ms_ExprDestroy(iftrue);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
-    if ((res = ParserParseSelectBody(prs, true, &iffalse)) == PARSE_ERROR) {
+    if ((res = ParserParseSelectBody(prs, true, &iffalse)) == MS_RESULT_ERROR) {
         ms_ExprDestroy(cond);
         ms_ExprDestroy(iftrue);
         return res;
@@ -1151,13 +1152,13 @@ static ms_ParseResult ParserParseSelectBody(ms_Parser *prs, bool saw_full_pair, 
     return ParserExprCombineConditional(prs, cond, iftrue, iffalse, select);
 }
 
-static ms_ParseResult ParserParseConditionalExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseConditionalExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *cond = NULL;
-    if ((res = ParserParseOrExpr(prs, &cond)) == PARSE_ERROR) {
+    if ((res = ParserParseOrExpr(prs, &cond)) == MS_RESULT_ERROR) {
         *expr = cond;
         return res;
     }
@@ -1169,7 +1170,7 @@ static ms_ParseResult ParserParseConditionalExpr(ms_Parser *prs, ms_Expr **expr)
 
     ParserConsumeToken(prs);
     ms_Expr *iftrue = NULL;
-    if ((res = ParserParseOrExpr(prs, &iftrue)) == PARSE_ERROR) {
+    if ((res = ParserParseOrExpr(prs, &iftrue)) == MS_RESULT_ERROR) {
         ms_ExprDestroy(cond);
         return res;
     }
@@ -1178,19 +1179,19 @@ static ms_ParseResult ParserParseConditionalExpr(ms_Parser *prs, ms_Expr **expr)
         ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, ":", prs->line, prs->col);
         ms_ExprDestroy(cond);
         ms_ExprDestroy(iftrue);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
     ms_Expr *iffalse = NULL;
-    if ((res = ParserParseOrExpr(prs, &iffalse)) == PARSE_ERROR) {
+    if ((res = ParserParseOrExpr(prs, &iffalse)) == MS_RESULT_ERROR) {
         ms_ExprDestroy(cond);
         ms_ExprDestroy(iftrue);
         return res;
     }
 
     ms_Expr *combined;
-    if ((res = ParserExprCombineConditional(prs, cond, iftrue, iffalse, &combined)) == PARSE_ERROR) {
+    if ((res = ParserExprCombineConditional(prs, cond, iftrue, iffalse, &combined)) == MS_RESULT_ERROR) {
         ms_ExprDestroy(cond);
         ms_ExprDestroy(iftrue);
         ms_ExprDestroy(iffalse);
@@ -1201,13 +1202,13 @@ static ms_ParseResult ParserParseConditionalExpr(ms_Parser *prs, ms_Expr **expr)
     return res;
 }
 
-static ms_ParseResult ParserParseOrExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseOrExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *left = NULL;
-    if ((res = ParserParseAndExpr(prs, &left)) == PARSE_ERROR) {
+    if ((res = ParserParseAndExpr(prs, &left)) == MS_RESULT_ERROR) {
         *expr = left;
         return res;
     }
@@ -1224,13 +1225,13 @@ static ms_ParseResult ParserParseOrExpr(ms_Parser *prs, ms_Expr **expr) {
 
         ParserConsumeToken(prs);
         ms_Expr *right = NULL;
-        if ((res = ParserParseAndExpr(prs, &right)) == PARSE_ERROR) {
+        if ((res = ParserParseAndExpr(prs, &right)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             return res;
         }
 
         ms_Expr *combined;
-        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == PARSE_ERROR) {
+        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             ms_ExprDestroy(right);
             return res;
@@ -1242,13 +1243,13 @@ static ms_ParseResult ParserParseOrExpr(ms_Parser *prs, ms_Expr **expr) {
     return res;
 }
 
-static ms_ParseResult ParserParseAndExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseAndExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *left = NULL;
-    if ((res = ParserParseEqualityExpr(prs, &left)) == PARSE_ERROR) {
+    if ((res = ParserParseEqualityExpr(prs, &left)) == MS_RESULT_ERROR) {
         *expr = left;
         return res;
     }
@@ -1265,13 +1266,13 @@ static ms_ParseResult ParserParseAndExpr(ms_Parser *prs, ms_Expr **expr) {
 
         ParserConsumeToken(prs);
         ms_Expr *right = NULL;
-        if ((res = ParserParseEqualityExpr(prs, &right)) == PARSE_ERROR) {
+        if ((res = ParserParseEqualityExpr(prs, &right)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             return res;
         }
 
         ms_Expr *combined;
-        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == PARSE_ERROR) {
+        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             ms_ExprDestroy(right);
             return res;
@@ -1283,13 +1284,13 @@ static ms_ParseResult ParserParseAndExpr(ms_Parser *prs, ms_Expr **expr) {
     return res;
 }
 
-static ms_ParseResult ParserParseEqualityExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseEqualityExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *left = NULL;
-    if ((res = ParserParseComparisonExpr(prs, &left)) == PARSE_ERROR) {
+    if ((res = ParserParseComparisonExpr(prs, &left)) == MS_RESULT_ERROR) {
         *expr = left;
         return res;
     }
@@ -1307,13 +1308,13 @@ static ms_ParseResult ParserParseEqualityExpr(ms_Parser *prs, ms_Expr **expr) {
 
         ParserConsumeToken(prs);
         ms_Expr *right = NULL;
-        if ((res = ParserParseComparisonExpr(prs, &right)) == PARSE_ERROR) {
+        if ((res = ParserParseComparisonExpr(prs, &right)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             return res;
         }
 
         ms_Expr *combined;
-        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == PARSE_ERROR) {
+        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             ms_ExprDestroy(right);
             return res;
@@ -1325,13 +1326,13 @@ static ms_ParseResult ParserParseEqualityExpr(ms_Parser *prs, ms_Expr **expr) {
     return res;
 }
 
-static ms_ParseResult ParserParseComparisonExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseComparisonExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *left = NULL;
-    if ((res = ParserParseBitwiseOrExpr(prs, &left)) == PARSE_ERROR) {
+    if ((res = ParserParseBitwiseOrExpr(prs, &left)) == MS_RESULT_ERROR) {
         *expr = left;
         return res;
     }
@@ -1351,13 +1352,13 @@ static ms_ParseResult ParserParseComparisonExpr(ms_Parser *prs, ms_Expr **expr) 
 
         ParserConsumeToken(prs);
         ms_Expr *right = NULL;
-        if ((res = ParserParseBitwiseOrExpr(prs, &right)) == PARSE_ERROR) {
+        if ((res = ParserParseBitwiseOrExpr(prs, &right)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             return res;
         }
 
         ms_Expr *combined;
-        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == PARSE_ERROR) {
+        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             ms_ExprDestroy(right);
             return res;
@@ -1369,13 +1370,13 @@ static ms_ParseResult ParserParseComparisonExpr(ms_Parser *prs, ms_Expr **expr) 
     return res;
 }
 
-static ms_ParseResult ParserParseBitwiseOrExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseBitwiseOrExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *left = NULL;
-    if ((res = ParserParseBitwiseXorExpr(prs, &left)) == PARSE_ERROR) {
+    if ((res = ParserParseBitwiseXorExpr(prs, &left)) == MS_RESULT_ERROR) {
         *expr = left;
         return res;
     }
@@ -1392,13 +1393,13 @@ static ms_ParseResult ParserParseBitwiseOrExpr(ms_Parser *prs, ms_Expr **expr) {
 
         ParserConsumeToken(prs);
         ms_Expr *right = NULL;
-        if ((res = ParserParseBitwiseXorExpr(prs, &right)) == PARSE_ERROR) {
+        if ((res = ParserParseBitwiseXorExpr(prs, &right)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             return res;
         }
 
         ms_Expr *combined;
-        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == PARSE_ERROR) {
+        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             ms_ExprDestroy(right);
             return res;
@@ -1410,13 +1411,13 @@ static ms_ParseResult ParserParseBitwiseOrExpr(ms_Parser *prs, ms_Expr **expr) {
     return res;
 }
 
-static ms_ParseResult ParserParseBitwiseXorExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseBitwiseXorExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *left;
-    if ((res = ParserParseBitwiseAndExpr(prs, &left)) == PARSE_ERROR) {
+    if ((res = ParserParseBitwiseAndExpr(prs, &left)) == MS_RESULT_ERROR) {
         *expr = left;
         return res;
     }
@@ -1433,12 +1434,12 @@ static ms_ParseResult ParserParseBitwiseXorExpr(ms_Parser *prs, ms_Expr **expr) 
 
         ParserConsumeToken(prs);
         ms_Expr *right;
-        if ((res = ParserParseBitwiseAndExpr(prs, &right)) == PARSE_ERROR) {
+        if ((res = ParserParseBitwiseAndExpr(prs, &right)) == MS_RESULT_ERROR) {
             return res;
         }
 
         ms_Expr *combined;
-        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == PARSE_ERROR) {
+        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
             return res;
         }
         left = combined;
@@ -1448,13 +1449,13 @@ static ms_ParseResult ParserParseBitwiseXorExpr(ms_Parser *prs, ms_Expr **expr) 
     return res;
 }
 
-static ms_ParseResult ParserParseBitwiseAndExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseBitwiseAndExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *left = NULL;
-    if ((res = ParserParseBitShiftExpr(prs, &left)) == PARSE_ERROR) {
+    if ((res = ParserParseBitShiftExpr(prs, &left)) == MS_RESULT_ERROR) {
         *expr = left;
         return res;
     }
@@ -1471,13 +1472,13 @@ static ms_ParseResult ParserParseBitwiseAndExpr(ms_Parser *prs, ms_Expr **expr) 
 
         ParserConsumeToken(prs);
         ms_Expr *right = NULL;
-        if ((res = ParserParseBitShiftExpr(prs, &right)) == PARSE_ERROR) {
+        if ((res = ParserParseBitShiftExpr(prs, &right)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             return res;
         }
 
         ms_Expr *combined;
-        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == PARSE_ERROR) {
+        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             ms_ExprDestroy(right);
             return res;
@@ -1489,13 +1490,13 @@ static ms_ParseResult ParserParseBitwiseAndExpr(ms_Parser *prs, ms_Expr **expr) 
     return res;
 }
 
-static ms_ParseResult ParserParseBitShiftExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseBitShiftExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *left = NULL;
-    if ((res = ParserParseArithmeticExpr(prs, &left)) == PARSE_ERROR) {
+    if ((res = ParserParseArithmeticExpr(prs, &left)) == MS_RESULT_ERROR) {
         *expr = left;
         return res;
     }
@@ -1513,13 +1514,13 @@ static ms_ParseResult ParserParseBitShiftExpr(ms_Parser *prs, ms_Expr **expr) {
 
         ParserConsumeToken(prs);
         ms_Expr *right = NULL;
-        if ((res = ParserParseArithmeticExpr(prs, &right)) == PARSE_ERROR) {
+        if ((res = ParserParseArithmeticExpr(prs, &right)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             return res;
         }
 
         ms_Expr *combined;
-        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == PARSE_ERROR) {
+        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             ms_ExprDestroy(right);
             return res;
@@ -1531,13 +1532,13 @@ static ms_ParseResult ParserParseBitShiftExpr(ms_Parser *prs, ms_Expr **expr) {
     return res;
 }
 
-static ms_ParseResult ParserParseArithmeticExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseArithmeticExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *left = NULL;
-    if ((res = ParserParseTermExpr(prs, &left)) == PARSE_ERROR) {
+    if ((res = ParserParseTermExpr(prs, &left)) == MS_RESULT_ERROR) {
         *expr = left;
         return res;
     }
@@ -1555,13 +1556,13 @@ static ms_ParseResult ParserParseArithmeticExpr(ms_Parser *prs, ms_Expr **expr) 
 
         ParserConsumeToken(prs);
         ms_Expr *right = NULL;
-        if ((res = ParserParseTermExpr(prs, &right)) == PARSE_ERROR) {
+        if ((res = ParserParseTermExpr(prs, &right)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             return res;
         }
 
         ms_Expr *combined;
-        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == PARSE_ERROR) {
+        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             ms_ExprDestroy(right);
             return res;
@@ -1573,13 +1574,13 @@ static ms_ParseResult ParserParseArithmeticExpr(ms_Parser *prs, ms_Expr **expr) 
     return res;
 }
 
-static ms_ParseResult ParserParseTermExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseTermExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *left = NULL;
-    if ((res = ParserParsePowerExpr(prs, &left)) == PARSE_ERROR) {
+    if ((res = ParserParsePowerExpr(prs, &left)) == MS_RESULT_ERROR) {
         *expr = left;
         return res;
     }
@@ -1599,13 +1600,13 @@ static ms_ParseResult ParserParseTermExpr(ms_Parser *prs, ms_Expr **expr) {
 
         ParserConsumeToken(prs);
         ms_Expr *right = NULL;
-        if ((res = ParserParsePowerExpr(prs, &right)) == PARSE_ERROR) {
+        if ((res = ParserParsePowerExpr(prs, &right)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             return res;
         }
 
         ms_Expr *combined;
-        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == PARSE_ERROR) {
+        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             ms_ExprDestroy(right);
             return res;
@@ -1617,13 +1618,13 @@ static ms_ParseResult ParserParseTermExpr(ms_Parser *prs, ms_Expr **expr) {
     return res;
 }
 
-static ms_ParseResult ParserParsePowerExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParsePowerExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *left = NULL;
-    if ((res = ParserParseUnaryExpr(prs, &left)) == PARSE_ERROR) {
+    if ((res = ParserParseUnaryExpr(prs, &left)) == MS_RESULT_ERROR) {
         *expr = left;
         return res;
     }
@@ -1640,13 +1641,13 @@ static ms_ParseResult ParserParsePowerExpr(ms_Parser *prs, ms_Expr **expr) {
 
         ParserConsumeToken(prs);
         ms_Expr *right = NULL;
-        if ((res = ParserParseTermExpr(prs, &right)) == PARSE_ERROR) {
+        if ((res = ParserParseTermExpr(prs, &right)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             return res;
         }
 
         ms_Expr *combined;
-        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == PARSE_ERROR) {
+        if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             ms_ExprDestroy(right);
             return res;
@@ -1658,11 +1659,11 @@ static ms_ParseResult ParserParsePowerExpr(ms_Parser *prs, ms_Expr **expr) {
     return res;
 }
 
-static ms_ParseResult ParserParseUnaryExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseUnaryExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res = PARSE_ERROR;
+    ms_Result res = MS_RESULT_ERROR;
     *expr = NULL;
 
     if (prs->cur) {
@@ -1674,7 +1675,7 @@ static ms_ParseResult ParserParseUnaryExpr(ms_Parser *prs, ms_Expr **expr) {
             case OP_MINUS:              /* fallthrough */
             case OP_UMINUS:             op = UNARY_MINUS;           break;
             default:
-                if ((res = ParserParseAtomExpr(prs, expr)) == PARSE_ERROR) {
+                if ((res = ParserParseAtomExpr(prs, expr)) == MS_RESULT_ERROR) {
                     return res;
                 }
                 goto parse_unary_expr_end_loop;
@@ -1683,11 +1684,11 @@ static ms_ParseResult ParserParseUnaryExpr(ms_Parser *prs, ms_Expr **expr) {
         ParserConsumeToken(prs);
 
         ms_Expr *inner = NULL;
-        if ((res = ParserParseUnaryExpr(prs, &inner)) == PARSE_ERROR) {
+        if ((res = ParserParseUnaryExpr(prs, &inner)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(inner);
             return res;
         }
-        if ((res = ParserExprCombineUnary(prs, inner, op, expr)) == PARSE_ERROR) {
+        if ((res = ParserExprCombineUnary(prs, inner, op, expr)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(inner);
             return res;
         }
@@ -1701,13 +1702,13 @@ parse_unary_expr_end_loop:
     return res;
 }
 
-static ms_ParseResult ParserParseAtomExpr(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseAtomExpr(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res;
+    ms_Result res;
     ms_Expr *left = NULL;
-    if ((res = ParserParseAtom(prs, &left)) == PARSE_ERROR) {
+    if ((res = ParserParseAtom(prs, &left)) == MS_RESULT_ERROR) {
         *expr = left;
         return res;
     }
@@ -1720,7 +1721,7 @@ static ms_ParseResult ParserParseAtomExpr(ms_Parser *prs, ms_Expr **expr) {
         ms_TokenType ttype = prs->cur->type;
         ms_ExprBinaryOp op;
         ms_Expr *right;
-        if ((res = ParserParseAccessor(prs, &right, &op)) == PARSE_ERROR) {
+        if ((res = ParserParseAccessor(prs, &right, &op)) == MS_RESULT_ERROR) {
             ms_ExprDestroy(left);
             return res;
         }
@@ -1731,13 +1732,13 @@ static ms_ParseResult ParserParseAtomExpr(ms_Parser *prs, ms_Expr **expr) {
              * expressions, since that is easier to deal with in bytecode
              * and is more representative of the actual meaning of attribute
              * access via brackets */
-            if ((res = ParserExprRewriteAttrAccess(prs, left, op, right, &combined)) == PARSE_ERROR) {
+            if ((res = ParserExprRewriteAttrAccess(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
                 ms_ExprDestroy(right);
                 ms_ExprDestroy(left);
                 return res;
             }
         } else {
-            if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == PARSE_ERROR) {
+            if ((res = ParserExprCombineBinary(prs, left, op, right, &combined)) == MS_RESULT_ERROR) {
                 ms_ExprDestroy(right);
                 ms_ExprDestroy(left);
                 return res;
@@ -1750,7 +1751,7 @@ static ms_ParseResult ParserParseAtomExpr(ms_Parser *prs, ms_Expr **expr) {
     return res;
 }
 
-static ms_ParseResult ParserParseAccessor(ms_Parser *prs, ms_Expr **expr, ms_ExprBinaryOp *op) {
+static ms_Result ParserParseAccessor(ms_Parser *prs, ms_Expr **expr, ms_ExprBinaryOp *op) {
     assert(prs);
     assert(expr);
 
@@ -1773,7 +1774,7 @@ static ms_ParseResult ParserParseAccessor(ms_Parser *prs, ms_Expr **expr, ms_Exp
 
             if (!ParserExpectToken(prs, IDENTIFIER)) {
                 ParserErrorSet(prs, ERR_EXPECTED_IDENTIFIER, prs->cur, prs->line, prs->col);
-                return PARSE_ERROR;
+                return MS_RESULT_ERROR;
             }
 
             ms_ValData p;
@@ -1782,21 +1783,21 @@ static ms_ParseResult ParserParseAccessor(ms_Parser *prs, ms_Expr **expr, ms_Exp
             *expr = ms_ExprNewWithVal(MSVAL_STR, p);
             if (!(*expr)) {
                 ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-                return PARSE_ERROR;
+                return MS_RESULT_ERROR;
             }
 
             ParserConsumeToken(prs);
             *op = (type == PERIOD) ?
                   (BINARY_GETATTR) :
                   (BINARY_SAFEGETATTR);
-            return PARSE_SUCCESS;
+            return MS_RESULT_SUCCESS;
         }
         default:
-            return PARSE_SUCCESS;
+            return MS_RESULT_SUCCESS;
     }
 }
 
-static ms_ParseResult ParserParseExprList(ms_Parser *prs, ms_Expr **list, ms_TokenType closer) {
+static ms_Result ParserParseExprList(ms_Parser *prs, ms_Expr **list, ms_TokenType closer) {
     assert(prs);
     assert(list);
 
@@ -1804,28 +1805,28 @@ static ms_ParseResult ParserParseExprList(ms_Parser *prs, ms_Expr **list, ms_Tok
                                       (dsarray_free_fn)ms_ExprDestroy);
     if (!params) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     *list = ms_ExprNewWithList(params);
     if (!(*list)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
         dsarray_destroy(params);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     /* no parameters, close and return */
     if ((prs->cur) && (prs->cur->type == closer)) {
         ParserConsumeToken(prs);
-        return PARSE_SUCCESS;
+        return MS_RESULT_SUCCESS;
     }
 
     /* produce the set of parameters */
     while(prs->cur) {
         ms_Expr *param;
-        if (ParserParseExpression(prs, &param) == PARSE_ERROR) {
+        if (ParserParseExpression(prs, &param) == MS_RESULT_ERROR) {
             dsarray_destroy(params);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
         dsarray_append(params, param);
         if (prs->cur) {
@@ -1836,25 +1837,25 @@ static ms_ParseResult ParserParseExprList(ms_Parser *prs, ms_Expr **list, ms_Tok
 
             if (!ParserExpectToken(prs, COMMA)) {
                 ms_ExprDestroy(*list);
-                return PARSE_ERROR;
+                return MS_RESULT_ERROR;
             }
             ParserConsumeToken(prs);
         }
     }
 
-    return PARSE_SUCCESS;
+    return MS_RESULT_SUCCESS;
 }
 
-static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
+static ms_Result ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
-    ms_ParseResult res = PARSE_SUCCESS;
+    ms_Result res = MS_RESULT_SUCCESS;
     ms_Token *cur = prs->cur;
 
     if (!cur) {
         ParserErrorSet(prs, ERR_EXPECTED_EXPRESSION, NULL, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     switch (cur->type) {
@@ -1864,7 +1865,7 @@ static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
             *expr = ms_ExprFloatFromString(val);
             if (!(*expr)) {
                 ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
-                res = PARSE_ERROR;
+                res = MS_RESULT_ERROR;
             }
             break;
         }
@@ -1876,7 +1877,7 @@ static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
             *expr = ms_ExprIntFromString(val);
             if (!(*expr)) {
                 ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
-                res = PARSE_ERROR;
+                res = MS_RESULT_ERROR;
             }
             break;
         }
@@ -1888,7 +1889,7 @@ static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
             *expr = ms_ExprNewWithVal(MSVAL_STR, p);
             if (!(*expr)) {
                 ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
-                res = PARSE_ERROR;
+                res = MS_RESULT_ERROR;
             }
             cur->value = NULL; /* prevent the buffer being destroyed when the token is destroyed */
             break;
@@ -1902,7 +1903,7 @@ static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
             *expr = ms_ExprNewWithVal(MSVAL_BOOL, p);
             if (!(*expr)) {
                 ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
-                res = PARSE_ERROR;
+                res = MS_RESULT_ERROR;
             }
             break;
         }
@@ -1914,7 +1915,7 @@ static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
             *expr = ms_ExprNewWithVal(MSVAL_NULL, p);
             if (!(*expr)) {
                 ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
-                res = PARSE_ERROR;
+                res = MS_RESULT_ERROR;
             }
             break;
         }
@@ -1926,7 +1927,7 @@ static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
             *expr = ms_ExprNewWithIdent(dsbuf_char_ptr(cur->value), dsbuf_len(cur->value));
             if (!(*expr)) {
                 ParserErrorSet(prs, ERR_OUT_OF_MEMORY, cur);
-                res = PARSE_ERROR;
+                res = MS_RESULT_ERROR;
             }
             break;
         }
@@ -1938,19 +1939,19 @@ static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
             /* parenthetical expression */
         case LPAREN:
             ParserConsumeToken(prs);
-            if ((res = ParserParseExpression(prs, expr)) == PARSE_ERROR) {
+            if ((res = ParserParseExpression(prs, expr)) == MS_RESULT_ERROR) {
                 return res;
             }
             if (!ParserExpectToken(prs, RPAREN)) {
                 ParserErrorSet(prs, ERR_MISMATCHED_PARENS, prs->cur, prs->line, prs->col);
-                return PARSE_ERROR;
+                return MS_RESULT_ERROR;
             }
             break;
 
             /* encountered another expression perhaps */
         default:
             ParserErrorSet(prs, ERR_EXPECTED_EXPRESSION, prs->cur, prs->line, prs->col);
-            res = PARSE_ERROR;
+            res = MS_RESULT_ERROR;
             break;
     }
 
@@ -1958,7 +1959,7 @@ static ms_ParseResult ParserParseAtom(ms_Parser *prs, ms_Expr **expr) {
     return res;
 }
 
-static ms_ParseResult ParserParseFunctionExpression(ms_Parser *prs, bool require_name, ms_Expr **expr) {
+static ms_Result ParserParseFunctionExpression(ms_Parser *prs, bool require_name, ms_Expr **expr) {
     assert(prs);
     assert(expr);
 
@@ -1994,19 +1995,19 @@ static ms_ParseResult ParserParseFunctionExpression(ms_Parser *prs, bool require
     ms_ValFunc *fn = calloc(1, sizeof(ms_ValFunc));
     if (!fn) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     *expr = ms_ExprNewWithFunc(fn);
     if (!(*expr)) {
         ms_ValFuncDestroy(fn);
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     if (!ParserExpectToken(prs, KW_FUNC)) {
         ParserErrorSet(prs, ERR_EXPECTED_KEYWORD, prs->cur, TOK_KW_FUNC, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
     ParserConsumeToken(prs);
 
@@ -2014,7 +2015,7 @@ static ms_ParseResult ParserParseFunctionExpression(ms_Parser *prs, bool require
     bool has_name = ParserExpectToken(prs, IDENTIFIER);
     if (!has_name && require_name) {
         ParserErrorSet(prs, ERR_EXPECTED_IDENTIFIER, prs->cur, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     /* steal the identifier for the declaration */
@@ -2022,7 +2023,7 @@ static ms_ParseResult ParserParseFunctionExpression(ms_Parser *prs, bool require
         fn->ident = malloc(sizeof(ms_Ident));
         if (!fn->ident) {
             ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
 
         fn->ident->name = prs->cur->value;
@@ -2034,7 +2035,7 @@ static ms_ParseResult ParserParseFunctionExpression(ms_Parser *prs, bool require
     /* parse the argument name list */
     if (!ParserExpectToken(prs, LPAREN)) {
         ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, "(", prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
     ParserConsumeToken(prs);
 
@@ -2042,20 +2043,20 @@ static ms_ParseResult ParserParseFunctionExpression(ms_Parser *prs, bool require
                                   (dsarray_free_fn)ms_IdentDestroy);
     if (!fn->args) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     while (!ParserExpectToken(prs, RPAREN)) {
         if (!ParserExpectToken(prs, IDENTIFIER)) {
             ParserErrorSet(prs, ERR_EXPECTED_IDENTIFIER, prs->cur, prs->line,
                            prs->col);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
 
         ms_Ident *ident = malloc(sizeof(ms_Ident));
         if (!ident) {
             ParserErrorSet(prs, ERR_OUT_OF_MEMORY, prs->cur);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
 
         ident->name = prs->cur->value;
@@ -2069,21 +2070,21 @@ static ms_ParseResult ParserParseFunctionExpression(ms_Parser *prs, bool require
         } else {
             if (!ParserExpectToken(prs, RPAREN)) {
                 ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, TOK_COMMA, prs->line, prs->col);
-                return PARSE_ERROR;
+                return MS_RESULT_ERROR;
             }
         }
     }
 
     if (!ParserExpectToken(prs, RPAREN)) {
         ParserErrorSet(prs, ERR_EXPECTED_TOKEN, prs->cur, TOK_RPAREN, prs->line, prs->col);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     ParserConsumeToken(prs);
     return ParserParseBlock(prs, &fn->block);
 }
 
-static ms_ParseResult ParserExprRewriteAttrAccess(ms_Parser *prs, ms_Expr *left, ms_ExprBinaryOp op, ms_Expr *right, ms_Expr **newexpr) {
+static ms_Result ParserExprRewriteAttrAccess(ms_Parser *prs, ms_Expr *left, ms_ExprBinaryOp op, ms_Expr *right, ms_Expr **newexpr) {
     assert(prs);
     assert(left);
     assert(right);
@@ -2121,7 +2122,7 @@ static ms_ParseResult ParserExprRewriteAttrAccess(ms_Parser *prs, ms_Expr *left,
         cur = ms_ExprNew(EXPRTYPE_BINARY);
         if (!cur) {
             ParserErrorSet(prs, ERR_OUT_OF_MEMORY, NULL);
-            return PARSE_ERROR;
+            return MS_RESULT_ERROR;
         }
 
         ms_Expr *rcur = dsarray_get(u->atom.list, i);
@@ -2141,10 +2142,10 @@ static ms_ParseResult ParserExprRewriteAttrAccess(ms_Parser *prs, ms_Expr *left,
 
     *newexpr = cur;
     ms_ExprDestroy(right);
-    return PARSE_SUCCESS;
+    return MS_RESULT_SUCCESS;
 }
 
-static ms_ParseResult ParserExprCombineConditional(ms_Parser *prs, ms_Expr *cond, ms_Expr *iftrue, ms_Expr *iffalse, ms_Expr **newexpr) {
+static ms_Result ParserExprCombineConditional(ms_Parser *prs, ms_Expr *cond, ms_Expr *iftrue, ms_Expr *iffalse, ms_Expr **newexpr) {
     assert(prs);
     assert(cond);
     assert(iftrue);
@@ -2154,17 +2155,17 @@ static ms_ParseResult ParserExprCombineConditional(ms_Parser *prs, ms_Expr *cond
     *newexpr = ms_ExprNew(EXPRTYPE_CONDITIONAL);
     if (!(*newexpr)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, NULL);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     *newexpr = ms_ExprFlatten(*newexpr, cond, EXPRLOC_COND);
     *newexpr = ms_ExprFlatten(*newexpr, iftrue, EXPRLOC_TRUE);
     *newexpr = ms_ExprFlatten(*newexpr, iffalse, EXPRLOC_FALSE);
 
-    return PARSE_SUCCESS;
+    return MS_RESULT_SUCCESS;
 }
 
-static ms_ParseResult ParserExprCombineBinary(ms_Parser *prs, ms_Expr *left, ms_ExprBinaryOp op, ms_Expr *right, ms_Expr **newexpr) {
+static ms_Result ParserExprCombineBinary(ms_Parser *prs, ms_Expr *left, ms_ExprBinaryOp op, ms_Expr *right, ms_Expr **newexpr) {
     assert(prs);
     assert(left);
     assert(right);
@@ -2173,17 +2174,17 @@ static ms_ParseResult ParserExprCombineBinary(ms_Parser *prs, ms_Expr *left, ms_
     *newexpr = ms_ExprNew(EXPRTYPE_BINARY);
     if (!(*newexpr)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, NULL);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     *newexpr = ms_ExprFlatten(*newexpr, left, EXPRLOC_LEFT);
     *newexpr = ms_ExprFlatten(*newexpr, right, EXPRLOC_RIGHT);
     (*newexpr)->cmpnt.b->op = op;
 
-    return PARSE_SUCCESS;
+    return MS_RESULT_SUCCESS;
 }
 
-static ms_ParseResult ParserExprCombineUnary(ms_Parser *prs, ms_Expr *inner, ms_ExprUnaryOp op, ms_Expr **newexpr) {
+static ms_Result ParserExprCombineUnary(ms_Parser *prs, ms_Expr *inner, ms_ExprUnaryOp op, ms_Expr **newexpr) {
     assert(prs);
     assert(inner);
     assert(newexpr);
@@ -2192,13 +2193,13 @@ static ms_ParseResult ParserExprCombineUnary(ms_Parser *prs, ms_Expr *inner, ms_
     *newexpr = ms_ExprNew(EXPRTYPE_UNARY);
     if (!(*newexpr)) {
         ParserErrorSet(prs, ERR_OUT_OF_MEMORY, NULL);
-        return PARSE_ERROR;
+        return MS_RESULT_ERROR;
     }
 
     *newexpr = ms_ExprFlatten(*newexpr, inner, EXPRLOC_UNARY);
     (*newexpr)->cmpnt.u->op = op;
 
-    return PARSE_SUCCESS;
+    return MS_RESULT_SUCCESS;
 }
 
 /* Move the pointer to the next token in the lexer stream without
@@ -2226,7 +2227,7 @@ static inline void ParserConsumeToken(ms_Parser *prs) {
 }
 
 /* Check if the next token to see if it matches our expected next token. */
-static bool ParserExpectToken(ms_Parser *prs, ms_TokenType type) {
+static inline bool ParserExpectToken(ms_Parser *prs, ms_TokenType type) {
     assert(prs);
 
     if ((!prs->cur) || (prs->cur->type != type)) {
@@ -2245,35 +2246,47 @@ static void ParserErrorSet(ms_Parser *prs, const char *msg, const ms_Token *tok,
         prs->err = NULL;
     }
 
-    prs->err = malloc(sizeof(ms_ParseError));
+    prs->err = malloc(sizeof(ms_Error));
     if (!prs->err) {
         return;
     }
 
-    va_list args, args2;
+    ms_Error *err = prs->err;
+    err->type = MS_ERROR_PARSER;
+
+    va_list args;
+    va_list argscpy;
     va_start(args, tok);
-    va_copy(args2, args);
+    va_copy(argscpy, args);
 
     int len = vsnprintf(NULL, 0, msg, args);
-    prs->err->msg = malloc((size_t)len + 1);
-    if (prs->err->msg) {
-        vsnprintf(prs->err->msg, len + 1, msg, args2);
+    if (len < 0) {
+        goto parser_close_error_va_args;
     }
 
-    prs->err->tok = (tok) ?
-                    ms_TokenNew(tok->type, dsbuf_char_ptr(tok->value),
-                                dsbuf_len(tok->value), tok->line, tok->col) :
-                    NULL;
+    err->len = (size_t)len;
+    err->msg = malloc((size_t)len + 1);
+    if (err->msg) {
+        vsnprintf(err->msg, len + 1, msg, argscpy);
+    }
+
+    err->detail.parse.tok = (tok) ?
+                            ms_TokenNew(tok->type, dsbuf_char_ptr(tok->value),
+                                        dsbuf_len(tok->value), tok->line, tok->col) :
+                            NULL;
+
+parser_close_error_va_args:
     va_end(args);
-    va_end(args2);
+    va_end(argscpy);
     return;
 }
 
 /* Clean up a Parse Error object. */
-static void ParseErrorDestroy(ms_ParseError *err) {
+static void ParseErrorDestroy(ms_Error *err) {
     if (!err) { return; }
-    ms_TokenDestroy(err->tok);
-    err->tok = NULL;
+    if (err->type != MS_ERROR_PARSER) { return; }
+    ms_TokenDestroy(err->detail.parse.tok);
+    err->detail.parse.tok = NULL;
     free(err->msg);
     err->msg = NULL;
     free(err);

--- a/src/parser.h
+++ b/src/parser.h
@@ -19,20 +19,10 @@
 
 #include <stdbool.h>
 #include "bytecode.h"
+#include "error.h"
 #include "lang.h"
 
 typedef struct ms_Parser ms_Parser;
-
-typedef enum ms_ParseResult {
-    PARSE_SUCCESS,          /** Parsing succeeded */
-    PARSE_WARNINGS,         /** Parsing succeeded but there may be some issues */
-    PARSE_ERROR             /** Parsing could not be completed */
-} ms_ParseResult;
-
-typedef struct ms_ParseError {
-    char *msg;              /** Error message returned from the parser */
-    ms_Token *tok;          /** Token potentially associated with the error */
-} ms_ParseError;
 
 /**
 * @brief Create a new @c ms_Parser object.
@@ -69,7 +59,7 @@ bool ms_ParserInitStringL(ms_Parser *prs, const char *str, size_t len);
 *          if the value is PARSE_ERROR or PARSE_WARNINGS, the caller can
 *          examine the value of @c to determine what went wrong
 */
-ms_ParseResult ms_ParserParse(ms_Parser *prs, ms_VMByteCode **code, const ms_AST **ast, const ms_ParseError **err);
+ms_Result ms_ParserParse(ms_Parser *prs, ms_VMByteCode **code, const ms_AST **ast, const ms_Error **err);
 
 /**
 * @brief Destroy a @c ms_Parser object.

--- a/src/parser.h
+++ b/src/parser.h
@@ -48,8 +48,6 @@ bool ms_ParserInitStringL(ms_Parser *prs, const char *str, size_t len);
 * @brief Parse the mscript string or file associated with this @c ms_Parser .
 *
 * @param prs a @c ms_Parser object
-* @param code a pointer to a pointer to hold the resultant byte-code; set to
-*        @c NULL if the return from this function is not @c PARSE_SUCCESS
 * @param ast if not @c NULL, the pointer will be set to the internal AST
 *        address; note that if another call is made to @c ms_ParserParse
 *        any previous pointer filled into this parameter will become invalid
@@ -59,7 +57,7 @@ bool ms_ParserInitStringL(ms_Parser *prs, const char *str, size_t len);
 *          if the value is PARSE_ERROR or PARSE_WARNINGS, the caller can
 *          examine the value of @c to determine what went wrong
 */
-ms_Result ms_ParserParse(ms_Parser *prs, ms_VMByteCode **code, const ms_AST **ast, const ms_Error **err);
+ms_Result ms_ParserParse(ms_Parser *prs, const ms_AST **ast, ms_Error **err);
 
 /**
 * @brief Destroy a @c ms_Parser object.

--- a/src/vm.h
+++ b/src/vm.h
@@ -21,44 +21,18 @@
 #include "libds/array.h"
 #include "libds/buffer.h"
 #include "bytecode.h"
+#include "error.h"
 #include "lang.h"
 
-/**
-* @brief Virtual machine object for executing mscript byte code
-*/
 typedef struct ms_VM ms_VM;
 
-/**
-* @brief Function signature for VM C functions
-*/
 typedef int (*ms_Function)(ms_VM *vm);
 
-/**
-* @brief Prototype of all objects
-*/
 typedef struct {
     const char *name;
     ms_Function func;
 } ms_FuncDef;
 
-/*
-* @brief Enumeration of VM result values
-*/
-typedef enum {
-    VMEXEC_SUCCESS,
-    VMEXEC_ERROR,
-} ms_VMExecResult;
-
-/*
-* @brief Structure describing an error that occurred in the mscript VM
-*/
-typedef struct {
-    char *msg;
-} ms_VMError;
-
-/**
-* @brief The explicit NULL pointer for the mscript VM.
-*/
 extern const void *MS_VM_NULL_POINTER;
 
 /**
@@ -74,13 +48,13 @@ ms_VM *ms_VMNew(void);
 * @param VM a @c ms_VM object
 * @param bc a @c ms_VMByteCode script container
 */
-ms_VMExecResult ms_VMExecute(ms_VM *vm, ms_VMByteCode *bc, const ms_VMError **err);
+ms_Result ms_VMExecute(ms_VM *vm, ms_VMByteCode *bc, ms_Error **err);
 
 /**
 * @brief Execute a bytecode script on the mscript VM and print any expression
 * left on the data stack.
 */
-ms_VMExecResult ms_VMExecuteAndPrint(ms_VM *vm, ms_VMByteCode *bc, const ms_VMError **err);
+ms_Result ms_VMExecuteAndPrint(ms_VM *vm, ms_VMByteCode *bc, ms_Error **err);
 
 /**
 * @brief Peek at the top data value on the current VM frame.

--- a/test/codegen.c
+++ b/test/codegen.c
@@ -3352,13 +3352,27 @@ static MunitResult TestCodeGenResultTuple(CodeGenResultTuple *tuples, size_t len
         munit_logf(MUNIT_LOG_INFO, "  code='%s'", tuple->val);
 
         const ms_AST *ast;
-        ms_VMByteCode *code;
-        const ms_Error *err;
-        ms_Result pres = ms_ParserParse(prs, &code, &ast, &err);
-        if (err) { munit_logf(MUNIT_LOG_INFO, "err = %s", err->msg); }
+        ms_Error *err;
+        ms_Result pres = ms_ParserParse(prs, &ast, &err);
+        if (err) {
+            munit_logf(MUNIT_LOG_INFO, "err = %s", err->msg);
+            ms_ErrorDestroy(err);
+        }
 
         munit_assert_cmp_int(pres, !=, MS_RESULT_ERROR);
+        munit_assert_non_null(ast);
+        munit_assert_null(err);
+
+        ms_VMByteCode *code;
+        ms_Result gres = ms_VMByteCodeGenerateFromAST(ast, &code, &err);
+        if (err) {
+            munit_logf(MUNIT_LOG_INFO, "err = %s", err->msg);
+            ms_ErrorDestroy(err);
+        }
+
+        munit_assert_cmp_int(gres, !=, MS_RESULT_ERROR);
         munit_assert_non_null(code);
+        munit_assert_null(err);
 
         CompareByteCode(code, tuple->bc);
         ms_VMByteCodeDestroy(code);

--- a/test/codegen.c
+++ b/test/codegen.c
@@ -3353,11 +3353,11 @@ static MunitResult TestCodeGenResultTuple(CodeGenResultTuple *tuples, size_t len
 
         const ms_AST *ast;
         ms_VMByteCode *code;
-        const ms_ParseError *err;
-        ms_ParseResult pres = ms_ParserParse(prs, &code, &ast, &err);
+        const ms_Error *err;
+        ms_Result pres = ms_ParserParse(prs, &code, &ast, &err);
         if (err) { munit_logf(MUNIT_LOG_INFO, "err = %s", err->msg); }
 
-        munit_assert_cmp_int(pres, !=, PARSE_ERROR);
+        munit_assert_cmp_int(pres, !=, MS_RESULT_ERROR);
         munit_assert_non_null(code);
 
         CompareByteCode(code, tuple->bc);

--- a/test/parser.c
+++ b/test/parser.c
@@ -437,15 +437,15 @@ MunitResult prs_TestParseErrors(const MunitParameter params[], void *user_data) 
     ms_Parser *prs = ms_ParserNew();
     munit_assert_non_null(prs);
 
-    ms_ParserInitString(prs, code);
-    ms_VMByteCode *bc;
-    const ms_Error *err;
-    ms_Result pres = ms_ParserParse(prs, &bc, NULL, &err);
+    munit_assert(ms_ParserInitString(prs, code));
+    const ms_AST *ast;
+    ms_Error *err;
+    ms_Result pres = ms_ParserParse(prs, &ast, &err);
 
     munit_assert_cmp_int(pres, ==, MS_RESULT_ERROR);
     munit_assert_non_null(err);
-    munit_assert_null(bc);
 
+    ms_ErrorDestroy(err);
     ms_ParserDestroy(prs);
     return MUNIT_OK;
 }
@@ -1764,18 +1764,19 @@ static MunitResult TestParseResultTuple(ParseResultTuple *tuples, size_t len) {
         munit_logf(MUNIT_LOG_INFO, "  code='%s'", tuple->val);
 
         const ms_AST *ast;
-        ms_VMByteCode *code;
-        const ms_Error *err;
-        ms_Result pres = ms_ParserParse(prs, &code, &ast, &err);
-        if (err) { munit_logf(MUNIT_LOG_INFO, "err = %s", err->msg); }
+        ms_Error *err;
+        ms_Result pres = ms_ParserParse(prs, &ast, &err);
+        if (err) {
+            munit_logf(MUNIT_LOG_INFO, "err = %s", err->msg);
+        }
 
         munit_assert_cmp_int(pres, !=, MS_RESULT_ERROR);
         munit_assert_non_null(ast);
         munit_assert_null(err);
 
         CompareASTToComponent(ast, tuple->type, &tuple->cmpnt);
-        ms_VMByteCodeDestroy(code);
         CleanParseResultTuple(tuple);
+        ms_ErrorDestroy(err);
     }
 
     ms_ParserDestroy(prs);

--- a/test/parser.c
+++ b/test/parser.c
@@ -439,10 +439,10 @@ MunitResult prs_TestParseErrors(const MunitParameter params[], void *user_data) 
 
     ms_ParserInitString(prs, code);
     ms_VMByteCode *bc;
-    const ms_ParseError *err;
-    ms_ParseResult pres = ms_ParserParse(prs, &bc, NULL, &err);
+    const ms_Error *err;
+    ms_Result pres = ms_ParserParse(prs, &bc, NULL, &err);
 
-    munit_assert_cmp_int(pres, ==, PARSE_ERROR);
+    munit_assert_cmp_int(pres, ==, MS_RESULT_ERROR);
     munit_assert_non_null(err);
     munit_assert_null(bc);
 
@@ -1765,11 +1765,11 @@ static MunitResult TestParseResultTuple(ParseResultTuple *tuples, size_t len) {
 
         const ms_AST *ast;
         ms_VMByteCode *code;
-        const ms_ParseError *err;
-        ms_ParseResult pres = ms_ParserParse(prs, &code, &ast, &err);
+        const ms_Error *err;
+        ms_Result pres = ms_ParserParse(prs, &code, &ast, &err);
         if (err) { munit_logf(MUNIT_LOG_INFO, "err = %s", err->msg); }
 
-        munit_assert_cmp_int(pres, !=, PARSE_ERROR);
+        munit_assert_cmp_int(pres, !=, MS_RESULT_ERROR);
         munit_assert_non_null(ast);
         munit_assert_null(err);
 


### PR DESCRIPTION
Unify the error types in the mscript C codebase. Previously the parser and VM had their own individual error types and result types; the bytecode generation had nothing at all. It's easier and more consistent to deal with a single error type.

In this pull request, I've also created a new public-facing API for simply executing mscript code from strings and files. Previously, `main.c` had to wrangle with all of the internal parser and VM APIs to just execute some code from the REPL loop. Now, everything is funneled through the single `ms_State` object (akin to Lua's `lua_State`).